### PR TITLE
fix issue 53 (Combobox shows 2 dropdowns with multi-instance template)

### DIFF
--- a/libs/PageForms.js
+++ b/libs/PageForms.js
@@ -1754,7 +1754,7 @@ $(document).ready( function() {
 
 		$( 'body' ).initializeJSElements(false);
 
-		// *** this does not seem necessary since 
+		// *** this does not seem necessary since
 		// initializeJSElements encompasses multiple loaded
 		// instances as well and initializeJSElements is
 		// otherwise called when a new instance is created

--- a/libs/PageForms.js
+++ b/libs/PageForms.js
@@ -1752,17 +1752,11 @@ $(document).ready( function() {
 			}
 		}
 
-		var $multipleInstance = $('form#pfForm').closest('.multipleTemplateInstance');
-		$( 'body' ).initializeJSElements($multipleInstance !== null);
-
-		// *** this does not seem necessary since
-		// initializeJSElements encompasses multiple loaded
-		// instances as well and initializeJSElements is
-		// otherwise called when a new instance is created
-		// for that specific instance
 		// $('.multipleTemplateInstance').each( function() {
 		// 	$(this).initializeJSElements(true);
 		// });
+		var $multipleInstance = $('form#pfForm').closest('.multipleTemplateInstance');
+		$( 'body' ).initializeJSElements($multipleInstance !== null);
 
 		$('.multipleTemplateAdder').click( function() {
 			$(this).addInstance( false );

--- a/libs/PageForms.js
+++ b/libs/PageForms.js
@@ -1754,9 +1754,14 @@ $(document).ready( function() {
 
 		$( 'body' ).initializeJSElements(false);
 
-		$('.multipleTemplateInstance').each( function() {
-			$(this).initializeJSElements(true);
-		});
+		// *** this does not seem necessary since 
+		// initializeJSElements encompasses multiple loaded
+		// instances as well and initializeJSElements is
+		// otherwise called when a new instance is created
+		// for that specific instance
+		// $('.multipleTemplateInstance').each( function() {
+		// 	$(this).initializeJSElements(true);
+		// });
 
 		$('.multipleTemplateAdder').click( function() {
 			$(this).addInstance( false );

--- a/libs/PageForms.js
+++ b/libs/PageForms.js
@@ -1752,7 +1752,8 @@ $(document).ready( function() {
 			}
 		}
 
-		$( 'body' ).initializeJSElements(false);
+		var $multipleInstance = $('form#pfForm').closest('.multipleTemplateInstance');
+		$( 'body' ).initializeJSElements($multipleInstance !== null);
 
 		// *** this does not seem necessary since
 		// initializeJSElements encompasses multiple loaded


### PR DESCRIPTION
fixes https://github.com/gesinn-it-pub/mediawiki-extensions-PageForms/issues/53
 (Combobox shows 2 dropdowns with multi-instance template)

although there are other solutions, like to add `.not('.pfComboBox .oo-ui-inputWidget-input') ` to the jQuery selector, the proposed solution is more general and prevents similar issues for other form inputs
