### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = git@github.com:gesinn-it-pub/docker-compose-ci.git
+	url = https://github.com/gesinn-it-pub/docker-compose-ci.git

--- a/includes/forminputs/PF_OpenLayersInput.php
+++ b/includes/forminputs/PF_OpenLayersInput.php
@@ -231,7 +231,7 @@ class PFOpenLayersInput extends PFFormInput {
 		}
 
 		foreach ( $secondsSymbols as $secondsSymbol ) {
-			$pattern = '/(\d+)' . $secondsSymbol . '/u';
+			$pattern = '/([\d.]+)' . $secondsSymbol . '/u';
 			if ( preg_match( $pattern, $coordinateStr, $matches ) ) {
 				$numSeconds = floatval( $matches[1] );
 				break;


### PR DESCRIPTION
see https://github.com/gesinn-it-pub/SemanticDependencyUpdater/pull/12/files and
https://github.com/gesinn-it-pub/SemanticDependencyUpdater/issues/13

without this, the error is shown:
`fatal: clone of 'git@github.com:gesinn-it-pub/docker-compose-ci.git' into submodule path '/opt/htdocs/mediawiki/extensions/PageForms/build' failed`