### PR TITLE
Issue 68 - add more tests for SpecialPages

### DIFF
--- a/.env-40
+++ b/.env-40
@@ -2,4 +2,7 @@
 MW_VERSION?=1.40
 PHP_VERSION?=8.1
 DB_TYPE?=mysql
-DB_IMAGE?=""
+DB_IMAGE?="mariadb:11.2"
+
+# extensions
+SMW_VERSION?=dev-master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             database_type: mysql
             database_image: "mysql:8"
             coverage: false
-            experimental: true
+            experimental: false
           - mediawiki_version: '1.40'
             smw_version: dev-master
             php_version: 8.1
@@ -51,7 +51,7 @@ jobs:
             database_type: mysql
             database_image: "mysql:8"
             coverage: false
-            experimental: true
+            experimental: false
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,33 +43,15 @@ jobs:
             database_image: "mysql:8"
             coverage: false
             experimental: true
-          # - mediawiki_version: '1.40'
-          #   smw_version: dev-master
-          #   php_version: 8.1
-          #   dt_version: 4.0.2
-          #   ps_version: 0.8
-          #   database_type: mysql
-          #   database_image: "mysql:8"
-          #   coverage: false
-          #   experimental: true
-          # - mediawiki_version: '1.40'
-          #   smw_version: dev-master
-          #   php_version: 8.1
-          #   dt_version: 4.0.2
-          #   ps_version: 0.8
-          #   database_type: mysql
-          #   database_image: "mariadb:latest"
-          #   coverage: false
-          #   experimental: true
-          # - mediawiki_version: '1.40'
-          #   smw_version: dev-master
-          #   php_version: 8.1
-          #   dt_version: 4.0.2
-          #   ps_version: 0.8
-          #   database_type: postgres
-          #   database_image: "postgres:14"
-          #   coverage: false
-          #   experimental: true
+          - mediawiki_version: '1.40'
+            smw_version: dev-master
+            php_version: 8.1
+            dt_version: 4.0.2
+            ps_version: 0.8
+            database_type: mysql
+            database_image: "mysql:8"
+            coverage: false
+            experimental: true
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,6 @@ jobs:
             database_image: "mysql:5.7"
             coverage: true
             experimental: false
-          - mediawiki_version: '1.35'
-            smw_version: '4.2.0'
-            php_version: 7.4
-            dt_version: 3.1
-            ps_version: 0.6.1
-            database_type: sqlite
-            coverage: false
-            experimental: false
           - mediawiki_version: '1.39'
             smw_version: '4.2.0'
             php_version: 8.1

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -12,14 +12,6 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
 
-		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
-		<exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
-		<exclude name="MediaWiki.Commenting.FunctionComment.MissingReturn" />
-		<exclude name="Generic.Files.OneObjectStructurePerFile.MultipleFound" />
-		<exclude name="MediaWiki.Classes.UnsortedUseStatements.UnsortedUse" />
-		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis.SingleSpaceBeforeCloseParenthesis" />
-		<exclude name="MediaWiki.Commenting.MissingCovers.MissingCovers" />
-		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPublic" />
 		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
 	</rule>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -11,8 +11,6 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionConfigUsage" />
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
-
-		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">
 		<properties>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -13,7 +13,6 @@
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
 		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
 		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
-		<exclude name="MediaWiki.Classes.UnsortedUseStatements.UnsortedUse" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">
 		<properties>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -11,6 +11,9 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionConfigUsage" />
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
+
+		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
+		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">
 		<properties>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -11,10 +11,6 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionConfigUsage" />
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
-
-		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
-		<exclude name="MediaWiki.Commenting.MissingCovers.MissingCovers" />
-		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">
 		<properties>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -11,6 +11,10 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionConfigUsage" />
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
+
+		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
+		<exclude name="MediaWiki.Commenting.MissingCovers.MissingCovers" />
+		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">
 		<properties>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -11,6 +11,12 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionConfigUsage" />
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
+
+		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis.SingleSpaceBeforeCloseParenthesis" />
+		<exclude name="MediaWiki.Commenting.MissingCovers.MissingCovers" />
+		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPublic" />
+		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
+		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">
 		<properties>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -11,11 +11,7 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionConfigUsage" />
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
-
-		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
-		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
 		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
-		<exclude name="MediaWiki.PHPUnit.AssertEquals.Int" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">
 		<properties>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -12,6 +12,11 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
 
+		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
+		<exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingReturn" />
+		<exclude name="Generic.Files.OneObjectStructurePerFile.MultipleFound" />
+		<exclude name="MediaWiki.Classes.UnsortedUseStatements.UnsortedUse" />
 		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis.SingleSpaceBeforeCloseParenthesis" />
 		<exclude name="MediaWiki.Commenting.MissingCovers.MissingCovers" />
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPublic" />

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -14,6 +14,8 @@
 
 		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
+		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
+		<exclude name="MediaWiki.PHPUnit.AssertEquals.Int" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">
 		<properties>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -12,7 +12,6 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
 		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
-		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">
 		<properties>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -12,7 +12,6 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
 
-		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -12,6 +12,8 @@
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionVarUsage" />
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
 		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
+		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
+		<exclude name="MediaWiki.Classes.UnsortedUseStatements.UnsortedUse" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">
 		<properties>

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ endif
 EXTENSION=PageForms
 
 # docker images
-MW_VERSION?=1.35
-PHP_VERSION?=7.4
-DB_TYPE?=sqlite
-DB_IMAGE?=""
+MW_VERSION?=1.39
+PHP_VERSION?=8.1
+DB_TYPE?=mysql
+DB_IMAGE?="mysql:8"
 
 # extensions
 SMW_VERSION?=4.2.0

--- a/tests/node-qunit/setup.js
+++ b/tests/node-qunit/setup.js
@@ -1,6 +1,13 @@
+const fs = require('fs');
+const path = require('path');
 const resetDom = createDom();
-const resetMediaWiki = prepareMediaWiki();
 const sinon = require('sinon');
+
+// Define paths for both versions
+const oojsJqueryPath = path.resolve(__dirname, '../../../../resources/lib/oojs/oojs.jquery.js');
+const oojsPath = path.resolve(__dirname, '../../../../resources/lib/oojs/oojs.js');
+
+const resetMediaWiki = prepareMediaWiki();
 
 QUnit.hooks.beforeEach(assert => {
 	sinon.assert.pass = message =>
@@ -57,7 +64,14 @@ function createDom() {
  * @return {(function(): void)|*} a function to reset mediaWiki between tests
  */
 function prepareMediaWiki() {
-	global.OO = require('../../../../resources/lib/oojs/oojs.jquery.js');
+	// Check if oojs.js exists (for MW 1.39+), otherwise use oojs.jquery.js (for MW 1.35)
+	if (fs.existsSync(oojsPath)) {
+		global.OO = require(oojsPath);
+	} else if (fs.existsSync(oojsJqueryPath)) {
+		global.OO = require(oojsJqueryPath);
+	} else {
+		throw new Error('Neither oojs.js nor oojs.jquery.js could be found.');
+	}
 	require('../../../../resources/lib/ooui/oojs-ui-core.js');
 	require('../../../../resources/lib/ooui/oojs-ui-widgets.js');
 	require('../../../../resources/lib/ooui/oojs-ui-wikimediaui.js');

--- a/tests/phpunit/integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -19,6 +19,7 @@ use MediaWiki\MediaWikiServices;
 use SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest;
 
 define( "TEST_NAMESPACE", 3000 );
+$wgExtraNamespaces[TEST_NAMESPACE] = "Test_Namespace";
 
 /**
  * @group PF
@@ -28,9 +29,6 @@ class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
 
     protected function setUp(): void {
         parent::setUp();
-
-        global $wgExtraNamespaces;
-        $wgExtraNamespaces[ TEST_NAMESPACE ] = "Test_Namespace";
 
         // Register parser functions directly
         $parser = $this->getParser();
@@ -52,27 +50,27 @@ class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
         return MediaWikiServices::getInstance()->getParser();
     }
 
-    protected function getTestCaseLocation() {
-        return __DIR__ . '/TestCases';
-    }
+	protected function getTestCaseLocation() {
+		return __DIR__ . '/TestCases';
+	}
 
-    protected function getPermittedSettings() {
-        return array_merge( parent::getPermittedSettings(), [
-            'wgPageFormsAutocompleteOnAllChars',
-            'wgAllowDisplayTitle',
-            'wgRestrictDisplayTitle',
-        ] );
-    }
+	protected function getPermittedSettings() {
+		return array_merge( parent::getPermittedSettings(), [
+			'wgPageFormsAutocompleteOnAllChars',
+			'wgAllowDisplayTitle',
+			'wgRestrictDisplayTitle',
+		] );
+	}
 
-    protected function getDependencyDefinitions() {
-        return [
-            'DisplayTitle' => static function ( $val, &$reason ) {
-                if ( !ExtensionRegistry::getInstance()->isLoaded( 'DisplayTitle' ) ) {
-                    $reason = "Dependency: DisplayTitle as requirement for the test is not available!";
-                    return false;
-                }
-                return true;
-            }
-        ];
-    }
+	protected function getDependencyDefinitions() {
+		return [
+			'DisplayTitle' => static function ( $val, &$reason ) {
+				if ( !ExtensionRegistry::getInstance()->isLoaded( 'DisplayTitle' ) ) {
+					$reason = "Dependency: DisplayTitle as requirement for the test is not available!";
+					return false;
+				}
+				return true;
+			}
+		];
+	}
 }

--- a/tests/phpunit/integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -27,28 +27,28 @@ $wgExtraNamespaces[TEST_NAMESPACE] = "Test_Namespace";
  */
 class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
 
-    protected function setUp(): void {
-        parent::setUp();
+	protected function setUp(): void {
+		parent::setUp();
 
-        // Register parser functions directly
-        $parser = $this->getParser();
-        $parser->setFunctionHook( 'default_form', [ PFDefaultForm::class, 'run' ] );
-        $parser->setFunctionHook( 'forminput', [ PFFormInputParserFunction::class, 'run' ] );
-        $parser->setFunctionHook( 'formlink', [ PFFormLink::class, 'run' ] );
-        $parser->setFunctionHook( 'formredlink', [ PFFormRedLink::class, 'run' ] );
-        $parser->setFunctionHook( 'queryformlink', [ PFQueryFormLink::class, 'run' ] );
-        $parser->setFunctionHook( 'arraymap', [ PFArrayMap::class, 'run' ], Parser::SFH_OBJECT_ARGS );
-        $parser->setFunctionHook( 'arraymaptemplate', [ PFArrayMapTemplate::class, 'run' ], Parser::SFH_OBJECT_ARGS );
-        $parser->setFunctionHook( 'autoedit', [ PFAutoEdit::class, 'run' ] );
-        $parser->setFunctionHook( 'autoedit_rating', [ PFAutoEditRating::class, 'run' ] );
-        $parser->setFunctionHook( 'template_params', [ PFTemplateParams::class, 'run' ] );
-        $parser->setFunctionHook( 'template_display', [ PFTemplateDisplay::class, 'run' ], Parser::SFH_OBJECT_ARGS );
-    }
+		// Register parser functions directly
+		$parser = $this->getParser();
+		$parser->setFunctionHook( 'default_form', [ PFDefaultForm::class, 'run' ] );
+		$parser->setFunctionHook( 'forminput', [ PFFormInputParserFunction::class, 'run' ] );
+		$parser->setFunctionHook( 'formlink', [ PFFormLink::class, 'run' ] );
+		$parser->setFunctionHook( 'formredlink', [ PFFormRedLink::class, 'run' ] );
+		$parser->setFunctionHook( 'queryformlink', [ PFQueryFormLink::class, 'run' ] );
+		$parser->setFunctionHook( 'arraymap', [ PFArrayMap::class, 'run' ], Parser::SFH_OBJECT_ARGS );
+		$parser->setFunctionHook( 'arraymaptemplate', [ PFArrayMapTemplate::class, 'run' ], Parser::SFH_OBJECT_ARGS );
+		$parser->setFunctionHook( 'autoedit', [ PFAutoEdit::class, 'run' ] );
+		$parser->setFunctionHook( 'autoedit_rating', [ PFAutoEditRating::class, 'run' ] );
+		$parser->setFunctionHook( 'template_params', [ PFTemplateParams::class, 'run' ] );
+		$parser->setFunctionHook( 'template_display', [ PFTemplateDisplay::class, 'run' ], Parser::SFH_OBJECT_ARGS );
+	}
 
-    protected function getParser(): Parser {
-        // Assuming you can retrieve a Parser instance here
-        return MediaWikiServices::getInstance()->getParser();
-    }
+	protected function getParser(): Parser {
+		// Assuming you can retrieve a Parser instance here
+		return MediaWikiServices::getInstance()->getParser();
+	}
 
 	protected function getTestCaseLocation() {
 		return __DIR__ . '/TestCases';

--- a/tests/phpunit/integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -3,19 +3,19 @@
 namespace PF\Tests\Integration\JSONScript;
 
 use ExtensionRegistry;
+use MediaWiki\MediaWikiServices;
 use Parser;
+use PFArrayMap;
+use PFArrayMapTemplate;
+use PFAutoEdit;
+use PFAutoEditRating;
 use PFDefaultForm;
 use PFFormInputParserFunction;
 use PFFormLink;
 use PFFormRedLink;
 use PFQueryFormLink;
-use PFArrayMap;
-use PFArrayMapTemplate;
-use PFAutoEdit;
-use PFAutoEditRating;
-use PFTemplateParams;
 use PFTemplateDisplay;
-use MediaWiki\MediaWikiServices;
+use PFTemplateParams;
 use SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest;
 
 define( "TEST_NAMESPACE", 3000 );

--- a/tests/phpunit/integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -3,11 +3,22 @@
 namespace PF\Tests\Integration\JSONScript;
 
 use ExtensionRegistry;
+use Parser;
+use PFDefaultForm;
+use PFFormInputParserFunction;
+use PFFormLink;
+use PFFormRedLink;
+use PFQueryFormLink;
+use PFArrayMap;
+use PFArrayMapTemplate;
+use PFAutoEdit;
+use PFAutoEditRating;
+use PFTemplateParams;
+use PFTemplateDisplay;
+use MediaWiki\MediaWikiServices;
 use SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest;
 
-// Putting the following in JsonTestCaseScriptRunnerTest::setUpBeforeClass didn't work:
 define( "TEST_NAMESPACE", 3000 );
-$wgExtraNamespaces[TEST_NAMESPACE] = "Test_Namespace";
 
 /**
  * @group PF
@@ -15,27 +26,53 @@ $wgExtraNamespaces[TEST_NAMESPACE] = "Test_Namespace";
  */
 class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
 
-	protected function getTestCaseLocation() {
-		return __DIR__ . '/TestCases';
-	}
+    protected function setUp(): void {
+        parent::setUp();
 
-	protected function getPermittedSettings() {
-		return array_merge( parent::getPermittedSettings(), [
-			'wgPageFormsAutocompleteOnAllChars',
-			'wgAllowDisplayTitle',
-			'wgRestrictDisplayTitle',
-		] );
-	}
+        global $wgExtraNamespaces;
+        $wgExtraNamespaces[ TEST_NAMESPACE ] = "Test_Namespace";
 
-	protected function getDependencyDefinitions() {
-		return [
-			'DisplayTitle' => static function ( $val, &$reason ) {
-				if ( !ExtensionRegistry::getInstance()->isLoaded( 'DisplayTitle' ) ) {
-					$reason = "Dependency: DisplayTitle as requirement for the test is not available!";
-					return false;
-				}
-				return true;
-			}
-		];
-	}
+        // Register parser functions directly
+        $parser = $this->getParser();
+        $parser->setFunctionHook( 'default_form', [ PFDefaultForm::class, 'run' ] );
+        $parser->setFunctionHook( 'forminput', [ PFFormInputParserFunction::class, 'run' ] );
+        $parser->setFunctionHook( 'formlink', [ PFFormLink::class, 'run' ] );
+        $parser->setFunctionHook( 'formredlink', [ PFFormRedLink::class, 'run' ] );
+        $parser->setFunctionHook( 'queryformlink', [ PFQueryFormLink::class, 'run' ] );
+        $parser->setFunctionHook( 'arraymap', [ PFArrayMap::class, 'run' ], Parser::SFH_OBJECT_ARGS );
+        $parser->setFunctionHook( 'arraymaptemplate', [ PFArrayMapTemplate::class, 'run' ], Parser::SFH_OBJECT_ARGS );
+        $parser->setFunctionHook( 'autoedit', [ PFAutoEdit::class, 'run' ] );
+        $parser->setFunctionHook( 'autoedit_rating', [ PFAutoEditRating::class, 'run' ] );
+        $parser->setFunctionHook( 'template_params', [ PFTemplateParams::class, 'run' ] );
+        $parser->setFunctionHook( 'template_display', [ PFTemplateDisplay::class, 'run' ], Parser::SFH_OBJECT_ARGS );
+    }
+
+    protected function getParser(): Parser {
+        // Assuming you can retrieve a Parser instance here
+        return MediaWikiServices::getInstance()->getParser();
+    }
+
+    protected function getTestCaseLocation() {
+        return __DIR__ . '/TestCases';
+    }
+
+    protected function getPermittedSettings() {
+        return array_merge( parent::getPermittedSettings(), [
+            'wgPageFormsAutocompleteOnAllChars',
+            'wgAllowDisplayTitle',
+            'wgRestrictDisplayTitle',
+        ] );
+    }
+
+    protected function getDependencyDefinitions() {
+        return [
+            'DisplayTitle' => static function ( $val, &$reason ) {
+                if ( !ExtensionRegistry::getInstance()->isLoaded( 'DisplayTitle' ) ) {
+                    $reason = "Dependency: DisplayTitle as requirement for the test is not available!";
+                    return false;
+                }
+                return true;
+            }
+        ];
+    }
 }

--- a/tests/phpunit/integration/JSONScript/TestCases/pf-forminput.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/pf-forminput.json
@@ -11,9 +11,7 @@
 		{
 			"type": "format",
 			"about": "forminput using FULLPAGENAME as value",
-			"skip-on": {
-				"mediawiki": [ ">1.38.x", "Check assertions failing, related to SMW" ]
-			},
+	
 			"subject": "Test_Namespace:1 & 2 + 3",
 			"assert-output": {
 				"to-contain": [

--- a/tests/phpunit/integration/JSONScript/TestCases/pf-forminput.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/pf-forminput.json
@@ -11,7 +11,6 @@
 		{
 			"type": "format",
 			"about": "forminput using FULLPAGENAME as value",
-	
 			"subject": "Test_Namespace:1 & 2 + 3",
 			"assert-output": {
 				"to-contain": [

--- a/tests/phpunit/integration/JSONScript/TestCases/pf-formlink.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/pf-formlink.json
@@ -85,6 +85,10 @@
 	"settings": {
 	},
 	"meta": {
+		"skip-on": {
+				"sqlite": "Update DisplayTitle ext PageProps:getInstance() call for MW > 1.39",
+				"mysql": "Update DisplayTitle ext PageProps:getInstance() call for MW > 1.39"
+			},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/integration/JSONScript/TestCases/pf-formlink.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/pf-formlink.json
@@ -28,9 +28,6 @@
 		{
 			"type": "format",
 			"about": "plain formlink",
-			"skip-on": {
-				"mediawiki": [ ">1.38.x", "Check assertions failing, related to SMW" ]
-			},
 			"subject": "plain formlink",
 			"assert-output": {
 				"to-contain": [
@@ -41,9 +38,6 @@
 		{
 			"type": "format",
 			"about": "plain formlink of type button",
-			"skip-on": {
-				"mediawiki": [ ">1.38.x", "Check assertions failing, related to SMW" ]
-			},
 			"subject": "plain formlink of type button",
 			"assert-output": {
 				"to-contain": [
@@ -56,9 +50,6 @@
 		{
 			"type": "format",
 			"about": "formlink using FULLPAGENAME as value",
-			"skip-on": {
-				"mediawiki": [ ">1.38.x", "Check assertions failing, related to SMW" ]
-			},
 			"subject": "Test_Namespace:1 & 2 + 3",
 			"assert-output": {
 				"to-contain": [
@@ -69,9 +60,6 @@
 		{
 			"type": "format",
 			"about": "formlink of type button using FULLPAGENAME as value",
-			"skip-on": {
-				"mediawiki": [ ">1.38.x", "Check assertions failing, related to SMW" ]
-			},
 			"subject": "Test_Namespace:1 & 2 + 3 button",
 			"assert-output": {
 				"to-contain": [

--- a/tests/phpunit/integration/includes/forminputs/PF_RadioButtonInputTest.php
+++ b/tests/phpunit/integration/includes/forminputs/PF_RadioButtonInputTest.php
@@ -52,12 +52,19 @@ class PFRadioButtonInputTest extends MediaWikiIntegrationTestCase {
 		$result = call_user_func_array(
 			[ 'PFRadioButtonInput', 'getHTML' ], $args
 		);
-
-		$this->assertRegexp(
-			'#' . $expected['expected_html'] . '#',
-			$result,
-			'asserts that getHTML() returns the correct HTML text'
-		);
+		if ( version_compare( MW_VERSION, '1.40', '<' ) ) {
+			$this->assertRegexp(
+				'#' . $expected['expected_html'] . '#',
+				$result,
+				'asserts that getHTML() returns the correct HTML text'
+			);
+		} else {
+			$this->assertMatchesRegularExpression(
+				'#' . $expected['expected_html'] . '#',
+				$result,
+				'asserts that getHTML() returns the correct HTML text'
+			);
+		}
 	}
 
 	/**
@@ -401,15 +408,28 @@ class PFRadioButtonInputTest extends MediaWikiIntegrationTestCase {
 				return;
 			}
 
-			if ( isset( $expected['expected_form_text'] ) ) {
+			// use assertMatchesRegularExpression instead of deprecated assertRegexp in MW higher then 1.39
+			if ( isset( $expected['expected_form_text'] ) && version_compare( MW_VERSION, '1.40', '<' ) ) {
 				$this->assertRegexp(
 					'#' . $expected['expected_form_text'] . '#',
 					$form_text,
 					'asserts that formHTML() returns the correct HTML text for the form'
 				);
+			} elseif ( isset( $expected['expected_form_text'] ) ) {
+				$this->assertMatchesRegularExpression(
+					'#' . $expected['expected_form_text'] . '#',
+					$form_text,
+					'asserts that formHTML() returns the correct HTML text for the form'
+				);
 			}
-			if ( isset( $expected['expected_page_text'] ) ) {
+			if ( isset( $expected['expected_page_text'] ) && version_compare( MW_VERSION, '1.40', '<' ) ) {
 				$this->assertRegexp(
+					'#' . $expected['expected_page_text'] . '#',
+					$page_text,
+					'assert that formHTML() returns the correct text for the page created'
+				);
+			} elseif ( isset( $expected['expected_page_text'] ) ) {
+				$this->assertMatchesRegularExpression(
 					'#' . $expected['expected_page_text'] . '#',
 					$page_text,
 					'assert that formHTML() returns the correct text for the page created'

--- a/tests/phpunit/integration/specials/PFCreateCategoryTest.php
+++ b/tests/phpunit/integration/specials/PFCreateCategoryTest.php
@@ -95,37 +95,37 @@ class PFCreateCategoryTest extends SpecialPageTestBase {
 	}
 
 	public function testForm() {
-        // Create new special page
-        $createCategory = $this->newSpecialPage();
-        $context = new RequestContext();
-        $createCategory->setContext( $context );
+		// Create new special page
+		$createCategory = $this->newSpecialPage();
+		$context = new RequestContext();
+		$createCategory->setContext( $context );
 
-        // Set the test values
-        $values = [
-            "title" => "Special:CreateCategory",
-            "category_name" => "NewCategory",
-            "default_form" => "ExampleForm",
-            "parent_category" => "ParentCategory",
-            "csrf" => $context->getUser()->getEditToken( 'CreateCategory' ),
-            "wpSave" => ""
-        ];
+		// Set the test values
+		$values = [
+			"title" => "Special:CreateCategory",
+			"category_name" => "NewCategory",
+			"default_form" => "ExampleForm",
+			"parent_category" => "ParentCategory",
+			"csrf" => $context->getUser()->getEditToken( 'CreateCategory' ),
+			"wpSave" => ""
+		];
 
-        // Set the values inside the page context
-        foreach ( $values as $k => $v ) {
-            $context->getRequest()->setVal( $k, $v );
-        }
+		// Set the values inside the page context
+		foreach ( $values as $k => $v ) {
+			$context->getRequest()->setVal( $k, $v );
+		}
 
-        // Execute the page
-        $createCategory->execute( null );
+		// Execute the page
+		$createCategory->execute( null );
 
-        // Get the page output
-        $output = $createCategory->getOutput();
+		// Get the page output
+		$output = $createCategory->getOutput();
 
 		// Additional DOMDocument checks
 		$dom = new DomDocument;
 		@$dom->loadHTML( $output->mBodytext );
 		$xpath = new DomXPath( $dom );
-	
+
 		// Query for the form element
 		$form = $xpath->query( '//form[contains(@action,"Category:NewCategory")]' )->item( 0 );
 		$this->assertNotNull( $form, 'Category creation form not found' );
@@ -133,7 +133,7 @@ class PFCreateCategoryTest extends SpecialPageTestBase {
 		$this->assertEquals( 'editform', $form->getAttribute( 'name' ) );
 		$this->assertEquals( 'post', $form->getAttribute( 'method' ) );
 		$this->assertEquals( '/index.php?title=Category:NewCategory&action=submit', $form->getAttribute( 'action' ), 'Form action does not match expected value' );
-		 
+
 		// Check for the presence of "Category:NewCategory" in the HTML body
 		$this->assertNotFalse( $xpath->query( ' //text()[contains(., "Category:NewCategory")]' )->length, 'Category:NewCategory text not found' );
 

--- a/tests/phpunit/integration/specials/PFCreateCategoryTest.php
+++ b/tests/phpunit/integration/specials/PFCreateCategoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * Integration test class for the PFCreateCategory special page.
  * This uses SpecialPageTestBase, designed for testing in the MediaWiki framework.
@@ -26,7 +28,7 @@ class PFCreateCategoryTest extends SpecialPageTestBase {
 	 */
 	protected function newSpecialPage() {
 		// Return an instance of PFCreateCategory
-		return new PFCreateCategory();
+		return MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage( 'CreateCategory' );
 	}
 
 	public function testGet() {

--- a/tests/phpunit/integration/specials/PFCreateCategoryTest.php
+++ b/tests/phpunit/integration/specials/PFCreateCategoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Integration test class for the PFCreateCategory special page.
+ * This uses MediaWikiIntegrationTestCase, designed for testing in the MediaWiki framework.
+ *
+ * @covers \PFCreateCategory
+ *
+ * @author gesinn-it-ilm
+ */
+class PFCreateCategoryTest extends MediaWikiIntegrationTestCase {
+
+	/**
+	 * Set up the test environment.
+	 * This is called before each test method.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+	}
+
+	public function testGet() {
+		// Instantiate the PFCreateCategory special page
+		$createCategoryPage = new PFCreateCategory();
+
+		// Set up the context manually with a simulated request
+		$context = RequestContext::getMain();
+		$request = new FauxRequest();
+		$context->setRequest( $request );
+
+		// Set the context and execute the special page
+		$createCategoryPage->setContext( $context );
+		$createCategoryPage->execute( null );
+
+		// Get the output of the page
+		$output = $createCategoryPage->getOutput();
+
+		// Assert that the title contains "Create a category"
+		$this->assertStringContainsString( "Create a category", $output->getPageTitle() );
+	}
+
+	/**
+	 * Test the createCategoryText method.
+	 */
+	public function testCreateCategoryText() {
+		$defaultForm = 'TestForm';
+		$categoryName = 'TestCategory';
+		$parentCategory = 'ParentCategory';
+
+		// Call the method and get the result
+		$categoryText = PFCreateCategory::createCategoryText( $defaultForm, $categoryName, $parentCategory );
+
+		// Check that the default form is inserted correctly
+		$this->assertStringContainsString( '{{#default_form:TestForm}}', $categoryText );
+
+		// Check that the parent category is added correctly
+		$this->assertStringContainsString( '[[Category:ParentCategory]]', $categoryText );
+	}
+
+	/**
+	 * Test for CSRF token validation in execute method.
+	 */
+	public function testCSRFProtection() {
+		$request = new FauxRequest( [
+			'wpSave' => true,
+			'csrf' => 'invalid-token',
+		] );
+
+		// Set up the context manually
+		$context = RequestContext::getMain();
+		$context->setRequest( $request );
+
+		// Execute the special page
+		$specialPage = new PFCreateCategory();
+		$specialPage->setContext( $context );
+		$specialPage->execute( null );
+
+		// Get the HTML output from the context
+		$outputText = $context->getOutput()->getHTML();
+
+		// Check that the CSRF protection message is shown
+		$this->assertStringContainsString( 'cross-site request forgery', $outputText );
+	}
+}

--- a/tests/phpunit/integration/specials/PFCreateCategoryTest.php
+++ b/tests/phpunit/integration/specials/PFCreateCategoryTest.php
@@ -2,13 +2,14 @@
 
 /**
  * Integration test class for the PFCreateCategory special page.
- * This uses MediaWikiIntegrationTestCase, designed for testing in the MediaWiki framework.
+ * This uses SpecialPageTestBase, designed for testing in the MediaWiki framework.
+ * SpecialPageTestBase extends MediaWikiIntegrationTestCase
  *
  * @covers \PFCreateCategory
  *
  * @author gesinn-it-ilm
  */
-class PFCreateCategoryTest extends MediaWikiIntegrationTestCase {
+class PFCreateCategoryTest extends SpecialPageTestBase {
 
 	/**
 	 * Set up the test environment.
@@ -18,9 +19,19 @@ class PFCreateCategoryTest extends MediaWikiIntegrationTestCase {
 		parent::setUp();
 	}
 
+	/**
+     * Create an instance of the special page being tested.
+     *
+     * @return SpecialPage
+     */
+    protected function newSpecialPage() {
+        // Return an instance of PFCreateCategory
+        return new PFCreateCategory();
+    }
+
 	public function testGet() {
 		// Instantiate the PFCreateCategory special page
-		$createCategoryPage = new PFCreateCategory();
+		$createCategoryPage = $this->newSpecialPage();
 
 		// Set up the context manually with a simulated request
 		$context = RequestContext::getMain();
@@ -70,7 +81,7 @@ class PFCreateCategoryTest extends MediaWikiIntegrationTestCase {
 		$context->setRequest( $request );
 
 		// Execute the special page
-		$specialPage = new PFCreateCategory();
+		$specialPage = $this->newSpecialPage();
 		$specialPage->setContext( $context );
 		$specialPage->execute( null );
 

--- a/tests/phpunit/integration/specials/PFCreateCategoryTest.php
+++ b/tests/phpunit/integration/specials/PFCreateCategoryTest.php
@@ -20,14 +20,14 @@ class PFCreateCategoryTest extends SpecialPageTestBase {
 	}
 
 	/**
-     * Create an instance of the special page being tested.
-     *
-     * @return SpecialPage
-     */
-    protected function newSpecialPage() {
-        // Return an instance of PFCreateCategory
-        return new PFCreateCategory();
-    }
+	 * Create an instance of the special page being tested.
+	 *
+	 * @return SpecialPage
+	 */
+	protected function newSpecialPage() {
+		// Return an instance of PFCreateCategory
+		return new PFCreateCategory();
+	}
 
 	public function testGet() {
 		// Instantiate the PFCreateCategory special page

--- a/tests/phpunit/integration/specials/PFCreateFormTest.php
+++ b/tests/phpunit/integration/specials/PFCreateFormTest.php
@@ -5,7 +5,7 @@
  *
  * @author gesinn-it-wam
  */
-class PFCreateFormTest extends MediaWikiIntegrationTestCase {
+class PFCreateFormTest extends SpecialPageTestBase {
 
 	use IntegrationTestHelpers;
 
@@ -14,8 +14,18 @@ class PFCreateFormTest extends MediaWikiIntegrationTestCase {
 		$this->requireLanguageCodeEn();
 	}
 
+	/**
+     * Create an instance of the special page being tested.
+     *
+     * @return SpecialPage
+     */
+    protected function newSpecialPage() {
+        // Return an instance of PFCreateForm
+        return new PFCreateForm();
+    }
+
 	public function testGet() {
-		$createForm = new PFCreateForm();
+		$createForm = $this->newSpecialPage();
 
 		$createForm->execute( null );
 

--- a/tests/phpunit/integration/specials/PFCreateFormTest.php
+++ b/tests/phpunit/integration/specials/PFCreateFormTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * @covers \PFCreateForm
  *
@@ -21,7 +23,7 @@ class PFCreateFormTest extends SpecialPageTestBase {
 	 */
 	protected function newSpecialPage() {
 		// Return an instance of PFCreateForm
-		return new PFCreateForm();
+		return MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage( 'CreateForm' );
 	}
 
 	public function testGet() {

--- a/tests/phpunit/integration/specials/PFCreateFormTest.php
+++ b/tests/phpunit/integration/specials/PFCreateFormTest.php
@@ -15,14 +15,14 @@ class PFCreateFormTest extends SpecialPageTestBase {
 	}
 
 	/**
-     * Create an instance of the special page being tested.
-     *
-     * @return SpecialPage
-     */
-    protected function newSpecialPage() {
-        // Return an instance of PFCreateForm
-        return new PFCreateForm();
-    }
+	 * Create an instance of the special page being tested.
+	 *
+	 * @return SpecialPage
+	 */
+	protected function newSpecialPage() {
+		// Return an instance of PFCreateForm
+		return new PFCreateForm();
+	}
 
 	public function testGet() {
 		$createForm = $this->newSpecialPage();

--- a/tests/phpunit/integration/specials/PFCreateFormTest.php
+++ b/tests/phpunit/integration/specials/PFCreateFormTest.php
@@ -36,31 +36,31 @@ class PFCreateFormTest extends SpecialPageTestBase {
 	}
 
 	public function testForm() {
-        $createForm = $this->newSpecialPage();
-        $context = new RequestContext();
-        $createForm->setContext( $context );
+		$createForm = $this->newSpecialPage();
+		$context = new RequestContext();
+		$createForm->setContext( $context );
 
-        $values = [
-            'form_name' => 'TestForm',
-            'template_1' => 'TestTemplate',
-            'label_1' => 'Test Label',
-            'allow_multiple_1' => true,
-            'csrf' => '+\\',
-            'wpSave' => ''
-        ];
+		$values = [
+			'form_name' => 'TestForm',
+			'template_1' => 'TestTemplate',
+			'label_1' => 'Test Label',
+			'allow_multiple_1' => true,
+			'csrf' => '+\\',
+			'wpSave' => ''
+		];
 
-        foreach ( $values as $k => $v ) {
-            $context->getRequest()->setVal( $k, $v );
-        }
+		foreach ( $values as $k => $v ) {
+			$context->getRequest()->setVal( $k, $v );
+		}
 
-        // Execute the special page with the given values
-        $createForm->execute( null );
-        $output = $createForm->getOutput();
+		// Execute the special page with the given values
+		$createForm->execute( null );
+		$output = $createForm->getOutput();
 
-        // Use DOM and XPath to assert form structure and content
-        $dom = new DOMDocument();
-        @$dom->loadHTML( $output->mBodytext ); 
-        $xpath = new DOMXPath( $dom );
+		// Use DOM and XPath to assert form structure and content
+		$dom = new DOMDocument();
+		@$dom->loadHTML( $output->mBodytext );
+		$xpath = new DOMXPath( $dom );
 
 		// Check that the form uses the 'post' method and has the correct action URL
 		$form = $xpath->query( "//form[@id='editform' and @method='post' and @action='/index.php?title=Form:TestForm&action=submit']" );
@@ -69,11 +69,11 @@ class PFCreateFormTest extends SpecialPageTestBase {
 		// Check for the wpSave hidden field
 		$wpSave = $xpath->query( "//input[@name='wpSave' and @type='hidden']" );
 		$this->assertNotNull( $wpSave->item( 0 ), "Save button hidden field not found" );
-		
+
 		// Check for the template_1
 		$this->assertStringContainsString( 'TestTemplate', $output->mBodytext, 'TestTemplate not found' );
 
 		// Check for the JavaScript that auto-submits the form
 		$this->assertStringContainsString( "document.editform.submit();", $output->mBodytext, "Form auto-submit script not found" );
-    }
+	}
 }

--- a/tests/phpunit/integration/specials/PFCreateFormTest.php
+++ b/tests/phpunit/integration/specials/PFCreateFormTest.php
@@ -35,4 +35,45 @@ class PFCreateFormTest extends SpecialPageTestBase {
 		$this->assertStringStartsWith( "Create a form", $output->getPageTitle() );
 	}
 
+	public function testForm() {
+        $createForm = $this->newSpecialPage();
+        $context = new RequestContext();
+        $createForm->setContext( $context );
+
+        $values = [
+            'form_name' => 'TestForm',
+            'template_1' => 'TestTemplate',
+            'label_1' => 'Test Label',
+            'allow_multiple_1' => true,
+            'csrf' => '+\\',
+            'wpSave' => ''
+        ];
+
+        foreach ( $values as $k => $v ) {
+            $context->getRequest()->setVal( $k, $v );
+        }
+
+        // Execute the special page with the given values
+        $createForm->execute( null );
+        $output = $createForm->getOutput();
+
+        // Use DOM and XPath to assert form structure and content
+        $dom = new DOMDocument();
+        @$dom->loadHTML( $output->mBodytext ); 
+        $xpath = new DOMXPath( $dom );
+
+		// Check that the form uses the 'post' method and has the correct action URL
+		$form = $xpath->query( "//form[@id='editform' and @method='post' and @action='/index.php?title=Form:TestForm&action=submit']" );
+		$this->assertNotNull( $form->item( 0 ), "Form not found or incorrect method/action" );
+
+		// Check for the wpSave hidden field
+		$wpSave = $xpath->query( "//input[@name='wpSave' and @type='hidden']" );
+		$this->assertNotNull( $wpSave->item( 0 ), "Save button hidden field not found" );
+		
+		// Check for the template_1
+		$this->assertStringContainsString( 'TestTemplate', $output->mBodytext, 'TestTemplate not found' );
+
+		// Check for the JavaScript that auto-submits the form
+		$this->assertStringContainsString( "document.editform.submit();", $output->mBodytext, "Form auto-submit script not found" );
+    }
 }

--- a/tests/phpunit/integration/specials/PFCreatePropertyTest.php
+++ b/tests/phpunit/integration/specials/PFCreatePropertyTest.php
@@ -12,14 +12,14 @@ class PFCreatePropertyTest extends SpecialPageTestBase {
 	}
 
 	/**
-     * Create an instance of the special page being tested.
-     *
-     * @return SpecialPage
-     */
-    protected function newSpecialPage() {
-        // Return an instance of PFCreateProperty
-        return new PFCreateProperty();
-    }
+	 * Create an instance of the special page being tested.
+	 *
+	 * @return SpecialPage
+	 */
+	protected function newSpecialPage() {
+		// Return an instance of PFCreateProperty
+		return new PFCreateProperty();
+	}
 
 	/**
 	 * Tests the execute method of the special page

--- a/tests/phpunit/integration/specials/PFCreatePropertyTest.php
+++ b/tests/phpunit/integration/specials/PFCreatePropertyTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @covers \PFCreateProperty
+ *
+ * @author gesinn-it-ilm
+ */
+class PFCreatePropertyTest extends MediaWikiIntegrationTestCase {
+
+    public function setUp(): void {
+		parent::setUp();
+	}
+
+	/**
+	 * Tests the execute method of the special page
+	 */
+	public function testExecute() {
+		// Set up the special page object
+		$specialPage = new PFCreateProperty();
+
+		// Create a simulated request
+		$request = new FauxRequest( [] );
+		$this->setMwGlobals( 'wgRequest', $request );
+
+		// Execute the special page and capture the output
+		$context = new RequestContext();
+		$context->setRequest( $request );
+		$context->setTitle( Title::newFromText( 'Special:CreateProperty' ) );
+		$output = $context->getOutput();
+		$specialPage->setContext( $context );
+
+		$specialPage->run( '' );
+		$htmlOutput = $output->getHTML();
+
+		// Assert that the output contains expected form elements
+		$this->assertStringContainsString( '<form action="" method="post">', $htmlOutput );
+		$this->assertStringContainsString( 'name="property_name"', $htmlOutput );
+		$this->assertStringContainsString( 'name="property_type"', $htmlOutput );
+		$this->assertStringContainsString( 'name="values"', $htmlOutput );
+		$this->assertStringContainsString( 'id="wpSave"', $htmlOutput );
+		$this->assertStringContainsString( 'id="wpPreview"', $htmlOutput );
+	}
+
+	/**
+	 * Tests form submission with missing CSRF token
+	 */
+	public function testFormSubmissionMissingCSRF() {
+		// Create a test user and request with missing CSRF token
+		$user = $this->getTestUser()->getUser();
+		$request = new FauxRequest( [
+			'property_name' => 'TestProperty',
+			'property_type' => 'String',
+			'values' => 'Value1, Value2',
+			'wpSave' => 'Save',
+		] );
+		$this->setMwGlobals( 'wgRequest', $request );
+
+		// Set up the special page object and context
+		$specialPage = new PFCreateProperty();
+		$context = new RequestContext();
+		$context->setRequest( $request );
+		$context->setTitle( Title::newFromText( 'Special:CreateProperty' ) );
+		$output = $context->getOutput();
+		$specialPage->setContext( $context );
+
+		// Run the page with the request
+		$specialPage->run( '' );
+
+		// Assert that the page detects the missing CSRF token
+		$htmlOutput = $output->getHTML();
+		$this->assertStringContainsString( 'cross-site request forgery', $htmlOutput );
+	}
+}

--- a/tests/phpunit/integration/specials/PFCreatePropertyTest.php
+++ b/tests/phpunit/integration/specials/PFCreatePropertyTest.php
@@ -7,7 +7,7 @@
  */
 class PFCreatePropertyTest extends MediaWikiIntegrationTestCase {
 
-    public function setUp(): void {
+	public function setUp(): void {
 		parent::setUp();
 	}
 

--- a/tests/phpunit/integration/specials/PFCreatePropertyTest.php
+++ b/tests/phpunit/integration/specials/PFCreatePropertyTest.php
@@ -5,18 +5,28 @@
  *
  * @author gesinn-it-ilm
  */
-class PFCreatePropertyTest extends MediaWikiIntegrationTestCase {
+class PFCreatePropertyTest extends SpecialPageTestBase {
 
 	public function setUp(): void {
 		parent::setUp();
 	}
 
 	/**
+     * Create an instance of the special page being tested.
+     *
+     * @return SpecialPage
+     */
+    protected function newSpecialPage() {
+        // Return an instance of PFCreateProperty
+        return new PFCreateProperty();
+    }
+
+	/**
 	 * Tests the execute method of the special page
 	 */
 	public function testExecute() {
 		// Set up the special page object
-		$specialPage = new PFCreateProperty();
+		$specialPage = $this->newSpecialPage();
 
 		// Create a simulated request
 		$request = new FauxRequest( [] );
@@ -56,7 +66,7 @@ class PFCreatePropertyTest extends MediaWikiIntegrationTestCase {
 		$this->setMwGlobals( 'wgRequest', $request );
 
 		// Set up the special page object and context
-		$specialPage = new PFCreateProperty();
+		$specialPage = $this->newSpecialPage();
 		$context = new RequestContext();
 		$context->setRequest( $request );
 		$context->setTitle( Title::newFromText( 'Special:CreateProperty' ) );

--- a/tests/phpunit/integration/specials/PFCreatePropertyTest.php
+++ b/tests/phpunit/integration/specials/PFCreatePropertyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * @covers \PFCreateProperty
  *
@@ -18,7 +20,7 @@ class PFCreatePropertyTest extends SpecialPageTestBase {
 	 */
 	protected function newSpecialPage() {
 		// Return an instance of PFCreateProperty
-		return new PFCreateProperty();
+		return MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage( 'CreateProperty' );
 	}
 
 	/**

--- a/tests/phpunit/integration/specials/PFCreateTemplateTest.php
+++ b/tests/phpunit/integration/specials/PFCreateTemplateTest.php
@@ -5,7 +5,7 @@
  *
  * @author gesinn-it-wam
  */
-class PFCreateTemplateTest extends MediaWikiIntegrationTestCase {
+class PFCreateTemplateTest extends SpecialPageTestBase {
 
 	use IntegrationTestHelpers;
 
@@ -14,8 +14,18 @@ class PFCreateTemplateTest extends MediaWikiIntegrationTestCase {
 		$this->requireLanguageCodeEn();
 	}
 
+	/**
+     * Create an instance of the special page being tested.
+     *
+     * @return SpecialPage
+     */
+    protected function newSpecialPage() {
+        // Return an instance of PFCreateTemplate
+        return new PFCreateTemplate();
+    }
+
 	public function testGetCreatePage() {
-		$createTemplate = new PFCreateTemplate();
+		$createTemplate = $this->newSpecialPage();
 
 		$createTemplate->execute( null );
 
@@ -24,7 +34,7 @@ class PFCreateTemplateTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testCreateTemplate() {
-		$createTemplate = new PFCreateTemplate();
+		$createTemplate = $this->newSpecialPage();
 		$context = new RequestContext();
 		$createTemplate->setContext( $context );
 		$values = [

--- a/tests/phpunit/integration/specials/PFCreateTemplateTest.php
+++ b/tests/phpunit/integration/specials/PFCreateTemplateTest.php
@@ -15,14 +15,14 @@ class PFCreateTemplateTest extends SpecialPageTestBase {
 	}
 
 	/**
-     * Create an instance of the special page being tested.
-     *
-     * @return SpecialPage
-     */
-    protected function newSpecialPage() {
-        // Return an instance of PFCreateTemplate
-        return new PFCreateTemplate();
-    }
+	 * Create an instance of the special page being tested.
+	 *
+	 * @return SpecialPage
+	 */
+	protected function newSpecialPage() {
+		// Return an instance of PFCreateTemplate
+		return new PFCreateTemplate();
+	}
 
 	public function testGetCreatePage() {
 		$createTemplate = $this->newSpecialPage();

--- a/tests/phpunit/integration/specials/PFCreateTemplateTest.php
+++ b/tests/phpunit/integration/specials/PFCreateTemplateTest.php
@@ -75,5 +75,26 @@ class PFCreateTemplateTest extends SpecialPageTestBase {
 		EOF;
 
 		$this->assertStringContainsString( '<form id="editform" name="editform" method="post" action="/index.php?title=Template:Thing&amp;action=submit"><input type="hidden" value="&lt;noinclude&gt;&#10;{{#template_params:Name (property=Foaf =&gt;name)}}&#10;&lt;/noinclude&gt;&lt;includeonly&gt;{| class=&quot;wikitable&quot;&#10;! Name&#10;| [[Foaf =&gt;name::{{{Name|}}}]]&#10;|-&#10;! &#10;|{{#ask:[[Foaf =&gt;homepage::{{SUBJECTPAGENAME}}]]|format=list}}&#10;|}&#10;&#10;[[Category:Thing]]&#10;&lt;/includeonly&gt;&#10;" name="wpTextbox1"/><input type="hidden" value="ℳ𝒲♥𝓊𝓃𝒾𝒸ℴ𝒹ℯ" name="wpUnicodeCheck"/><input type="hidden" name="wpSummary"/><input type="hidden" value="+\" name="wpEditToken"/><input type="hidden" name="wpSave"/><input type="hidden" value="1" name="wpUltimateParam"/></form>', $output->mBodytext );
+
+		// Load the HTML with DOMDocument and DOMXPath
+		$dom = new DomDocument;
+		@$dom->loadHTML( $output->mBodytext );
+		$xpath = new DomXPath( $dom );
+
+		// Check if the form exists with the correct action
+		$form = $xpath->query( '//form[contains(@action,"Template:Thing")]' )->item( 0 );
+		$this->assertNotNull( $form, 'Form element not found' );
+
+		// Debugging: Check if wpTextbox1 input exists in the DOM
+		$templateInput = $xpath->query( '//input[@name="wpTextbox1"]' )->item( 0 );
+		$this->assertNotNull( $templateInput, 'Template input field not found' );
+
+		// Check for wpSave field
+		$wpSave = $xpath->query( '//input[@name="wpSave"]' )->item( 0 );
+		$this->assertNotNull( $wpSave, 'wpSave input field not found' );
+
+		// Check for script tag that submits the form
+		$script = $xpath->query( '//script[contains(text(),"document.editform.submit();")]' )->item( 0 );
+		$this->assertNotNull( $script, 'Script for form submission not found' );
 	}
 }

--- a/tests/phpunit/integration/specials/PFCreateTemplateTest.php
+++ b/tests/phpunit/integration/specials/PFCreateTemplateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * @covers \PFCreateTemplate
  *
@@ -21,7 +23,7 @@ class PFCreateTemplateTest extends SpecialPageTestBase {
 	 */
 	protected function newSpecialPage() {
 		// Return an instance of PFCreateTemplate
-		return new PFCreateTemplate();
+		return MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage( 'CreateTemplate' );
 	}
 
 	public function testGetCreatePage() {

--- a/tests/phpunit/integration/specials/PFFormEditTest.php
+++ b/tests/phpunit/integration/specials/PFFormEditTest.php
@@ -59,6 +59,9 @@ class PFFormEditTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testPrintAltFormsList() {
+		if ( version_compare( MW_VERSION, '1.38', '>' ) ) {
+			$this->markTestSkipped( 'Check how to properly register special page inside tests for MW 1.39 and higher!' );
+		}
 		// Sample input data
 		$altForms = [ 'Form1', 'Form2' ];
 		$targetName = 'TargetPage';

--- a/tests/phpunit/integration/specials/PFFormEditTest.php
+++ b/tests/phpunit/integration/specials/PFFormEditTest.php
@@ -19,14 +19,14 @@ class PFFormEditTest extends SpecialPageTestBase {
 	}
 
 	/**
-     * Create an instance of the special page being tested.
-     *
-     * @return SpecialPage
-     */
-    protected function newSpecialPage() {
-        // Return an instance of PFFormEdit
-        return new PFFormEdit();
-    }
+	 * Create an instance of the special page being tested.
+	 *
+	 * @return SpecialPage
+	 */
+	protected function newSpecialPage() {
+		// Return an instance of PFFormEdit
+		return new PFFormEdit();
+	}
 
 	public function testEmptyQuery() {
 		$formEdit = $this->newSpecialPage();

--- a/tests/phpunit/integration/specials/PFFormEditTest.php
+++ b/tests/phpunit/integration/specials/PFFormEditTest.php
@@ -8,7 +8,7 @@
  *
  * @author gesinn-it-wam
  */
-class PFFormEditTest extends MediaWikiIntegrationTestCase {
+class PFFormEditTest extends SpecialPageTestBase {
 
 	use IntegrationTestHelpers;
 
@@ -18,8 +18,18 @@ class PFFormEditTest extends MediaWikiIntegrationTestCase {
 		$this->tablesUsed[] = 'page';
 	}
 
+	/**
+     * Create an instance of the special page being tested.
+     *
+     * @return SpecialPage
+     */
+    protected function newSpecialPage() {
+        // Return an instance of PFFormEdit
+        return new PFFormEdit();
+    }
+
 	public function testEmptyQuery() {
-		$formEdit = new PFFormEdit();
+		$formEdit = $this->newSpecialPage();
 
 		$formEdit->execute( null );
 
@@ -28,7 +38,7 @@ class PFFormEditTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testInvalidForm() {
-		$formEdit = new PFFormEdit();
+		$formEdit = $this->newSpecialPage();
 
 		$formEdit->execute( "InvalidForm/X" );
 
@@ -48,7 +58,7 @@ class PFFormEditTest extends MediaWikiIntegrationTestCase {
 			{{{end template}}}
 		EOF;
 		$this->insertPage( 'Form:Thing', $formText );
-		$formEdit = new PFFormEdit();
+		$formEdit = $this->newSpecialPage();
 
 		$formEdit->execute( "Thing/Thing1" );
 
@@ -83,7 +93,7 @@ class PFFormEditTest extends MediaWikiIntegrationTestCase {
 		$this->setMwGlobals( 'wgSpecialPages', [ 'FormEdit' => $mockSpecialPage ] );
 
 		// Create an instance of the class that contains printAltFormsList
-		$pfFormEdit = new PFFormEdit();
+		$pfFormEdit = $this->newSpecialPage();
 
 		// Run the method with the mocked objects and inputs
 		$output = $pfFormEdit->printAltFormsList( $altForms, $targetName );

--- a/tests/phpunit/integration/specials/PFFormEditTest.php
+++ b/tests/phpunit/integration/specials/PFFormEditTest.php
@@ -71,25 +71,25 @@ class PFFormEditTest extends SpecialPageTestBase {
 	}
 
 	public function testPrintAltFormsList() {
-        // Create an instance of PFFormEdit
-        $formEdit = $this->newSpecialPage();
+		// Create an instance of PFFormEdit
+		$formEdit = $this->newSpecialPage();
 
-        // Prepare input for the test
-        $alt_forms = [ 'FormA', 'FormB', 'FormC' ];
-        $target_name = 'SampleTarget';
+		// Prepare input for the test
+		$alt_forms = [ 'FormA', 'FormB', 'FormC' ];
+		$target_name = 'SampleTarget';
 
-        // Expected URL for the special page
-        $fe_url = SpecialPage::getTitleFor( 'FormEdit' )->getFullURL();
-        
-        // Manually construct the expected output
-        $expected_output = '<a href="' . $fe_url . '/FormA/SampleTarget">FormA</a>, ' .
-                           '<a href="' . $fe_url . '/FormB/SampleTarget">FormB</a>, ' .
-                           '<a href="' . $fe_url . '/FormC/SampleTarget">FormC</a>';
-        
-        // Call the method being tested
-        $result = $formEdit->printAltFormsList( $alt_forms, $target_name );
+		// Expected URL for the special page
+		$fe_url = SpecialPage::getTitleFor( 'FormEdit' )->getFullURL();
 
-        // Assert that the result matches the expected output
-        $this->assertEquals( $expected_output, $result );
-    }
+		// Manually construct the expected output
+		$expected_output = '<a href="' . $fe_url . '/FormA/SampleTarget">FormA</a>, ' .
+						   '<a href="' . $fe_url . '/FormB/SampleTarget">FormB</a>, ' .
+						   '<a href="' . $fe_url . '/FormC/SampleTarget">FormC</a>';
+
+		// Call the method being tested
+		$result = $formEdit->printAltFormsList( $alt_forms, $target_name );
+
+		// Assert that the result matches the expected output
+		$this->assertEquals( $expected_output, $result );
+	}
 }

--- a/tests/phpunit/integration/specials/PFFormEditTest.php
+++ b/tests/phpunit/integration/specials/PFFormEditTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * @covers \PFFormEdit
  * @covers \PFAutoeditAPI
@@ -25,7 +27,7 @@ class PFFormEditTest extends SpecialPageTestBase {
 	 */
 	protected function newSpecialPage() {
 		// Return an instance of PFFormEdit
-		return new PFFormEdit();
+		return MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage( 'FormEdit' );
 	}
 
 	public function testEmptyQuery() {
@@ -69,40 +71,25 @@ class PFFormEditTest extends SpecialPageTestBase {
 	}
 
 	public function testPrintAltFormsList() {
-		if ( version_compare( MW_VERSION, '1.38', '>' ) ) {
-			$this->markTestSkipped( 'Check how to properly register special page inside tests for MW 1.39 and higher!' );
-		}
-		// Sample input data
-		$altForms = [ 'Form1', 'Form2' ];
-		$targetName = 'TargetPage';
+        // Create an instance of PFFormEdit
+        $formEdit = $this->newSpecialPage();
 
-		// Mocking the PFUtils::getSpecialPage method
-		$mockSpecialPage = $this->createMock( SpecialPage::class );
-		$mockTitle = $this->createMock( Title::class );
+        // Prepare input for the test
+        $alt_forms = [ 'FormA', 'FormB', 'FormC' ];
+        $target_name = 'SampleTarget';
 
-		// Set expectations on the mocked objects
-		$mockTitle->expects( $this->once() )
-			->method( 'getFullURL' )
-			->willReturn( 'https://example.com/index.php/Special:FormEdit' );
+        // Expected URL for the special page
+        $fe_url = SpecialPage::getTitleFor( 'FormEdit' )->getFullURL();
+        
+        // Manually construct the expected output
+        $expected_output = '<a href="' . $fe_url . '/FormA/SampleTarget">FormA</a>, ' .
+                           '<a href="' . $fe_url . '/FormB/SampleTarget">FormB</a>, ' .
+                           '<a href="' . $fe_url . '/FormC/SampleTarget">FormC</a>';
+        
+        // Call the method being tested
+        $result = $formEdit->printAltFormsList( $alt_forms, $target_name );
 
-		$mockSpecialPage->expects( $this->once() )
-			->method( 'getPageTitle' )
-			->willReturn( $mockTitle );
-
-		// Replace the static method call in PFUtils with the mock
-		$this->setMwGlobals( 'wgSpecialPages', [ 'FormEdit' => $mockSpecialPage ] );
-
-		// Create an instance of the class that contains printAltFormsList
-		$pfFormEdit = $this->newSpecialPage();
-
-		// Run the method with the mocked objects and inputs
-		$output = $pfFormEdit->printAltFormsList( $altForms, $targetName );
-
-		// Check the expected HTML output
-		$expectedOutput = '<a href="https://example.com/index.php/Special:FormEdit/Form1/TargetPage">Form1</a>, ' .
-						  '<a href="https://example.com/index.php/Special:FormEdit/Form2/TargetPage">Form2</a>';
-
-		// Assert the output matches the expected result
-		$this->assertEquals( $expectedOutput, $output );
-	}
+        // Assert that the result matches the expected output
+        $this->assertEquals( $expected_output, $result );
+    }
 }

--- a/tests/phpunit/integration/specials/PFFormStartTest.php
+++ b/tests/phpunit/integration/specials/PFFormStartTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * @covers \PFFormStart
  *
@@ -21,7 +23,7 @@ class PFFormStartTest extends SpecialPageTestBase {
 	 */
 	protected function newSpecialPage() {
 		// Return an instance of PFFormStart
-		return new PFFormStart();
+		return MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage( 'FormStart' );
 	}
 
 	public function testEmptyQuery() {

--- a/tests/phpunit/integration/specials/PFFormStartTest.php
+++ b/tests/phpunit/integration/specials/PFFormStartTest.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * @covers \PFCreateForm
+ * @covers \PFFormStart
  *
  * @author gesinn-it-wam
  */
-class PFFormStartTest extends MediaWikiIntegrationTestCase {
+class PFFormStartTest extends SpecialPageTestBase {
 
 	use IntegrationTestHelpers;
 
@@ -14,8 +14,18 @@ class PFFormStartTest extends MediaWikiIntegrationTestCase {
 		$this->requireLanguageCodeEn();
 	}
 
+	/**
+     * Create an instance of the special page being tested.
+     *
+     * @return SpecialPage
+     */
+    protected function newSpecialPage() {
+        // Return an instance of PFFormStart
+        return new PFFormStart();
+    }
+
 	public function testEmptyQuery() {
-		$formStart = new PFFormStart();
+		$formStart = $this->newSpecialPage();
 
 		$formStart->execute( null );
 

--- a/tests/phpunit/integration/specials/PFFormStartTest.php
+++ b/tests/phpunit/integration/specials/PFFormStartTest.php
@@ -15,14 +15,14 @@ class PFFormStartTest extends SpecialPageTestBase {
 	}
 
 	/**
-     * Create an instance of the special page being tested.
-     *
-     * @return SpecialPage
-     */
-    protected function newSpecialPage() {
-        // Return an instance of PFFormStart
-        return new PFFormStart();
-    }
+	 * Create an instance of the special page being tested.
+	 *
+	 * @return SpecialPage
+	 */
+	protected function newSpecialPage() {
+		// Return an instance of PFFormStart
+		return new PFFormStart();
+	}
 
 	public function testEmptyQuery() {
 		$formStart = $this->newSpecialPage();

--- a/tests/phpunit/integration/specials/PFMultiPageEditTest.php
+++ b/tests/phpunit/integration/specials/PFMultiPageEditTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Integration tests for the PFMultiPageEdit class.
+ *
+ * @covers \PFMultiPageEdit
+ *
+ * @group Database
+ *
+ * @author gesinn-it-ilm
+ */
+class PFMultiPageEditTest extends MediaWikiIntegrationTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        // Ensure the user has the correct permissions for the test
+        $this->setMwGlobals( 'wgGroupPermissions', [
+            '*' => [ 'multipageedit' => true ],
+            'user' => [ 'multipageedit' => true ]
+        ] );
+    }
+
+    /**
+     * Test executing with template and form parameters.
+     */
+    public function testExecuteWithTemplateAndForm() {
+        // Create a FauxRequest to simulate passing 'template' and 'form' parameters.
+        $params = [
+            'template' => 'TestTemplate',
+            'form' => 'TestForm'
+        ];
+        $request = new FauxRequest( $params );
+
+        // Set the request in the context using RequestContext.
+        RequestContext::getMain()->setRequest( $request );
+
+        // Create an instance of PFMultiPageEdit and call execute().
+        $specialPage = new PFMultiPageEdit();
+        $specialPage->execute( null );
+
+        // Fetch the OutputPage object from the context.
+        $output = RequestContext::getMain()->getOutput();
+
+        // Check assertions on the output.
+        $this->assertNotEmpty( $output->getHTML(), 'The page output should not be empty' );
+        $this->assertStringContainsString( 'TestTemplate', $output->getHTML(), 'The template name should appear in the output' );
+    }
+
+    /**
+     * Test the displaySpreadsheet function by mocking a template and form.
+     */
+    public function testDisplaySpreadsheet() {
+        // Create a FauxRequest to simulate passing 'template' and 'form' parameters.
+        $params = [
+            'template' => 'TestTemplate',
+            'form' => 'TestForm'
+        ];
+        $request = new FauxRequest( $params );
+        // Set the request in the context using RequestContext.
+        RequestContext::getMain()->setRequest( $request );
+
+        // Mock the necessary template and form data.
+        $this->editPage( 'Template:TestTemplate', 'Field1|Field2' );
+        $this->editPage( 'Form:TestForm', '{{{for template|TestTemplate}}}' );
+
+        // Create an instance of PFMultiPageEdit and call execute to trigger displaySpreadsheet().
+        $specialPage = new PFMultiPageEdit();
+        $specialPage->execute( null );
+
+        // Fetch the OutputPage object from the context.
+        $output = RequestContext::getMain()->getOutput();
+
+        // Instead of looking for 'Spreadsheet interface', let's look for part of the actual output.
+        $this->assertStringContainsString( 'class="pfSpreadsheet"', $output->getHTML(), 'The spreadsheet interface should be displayed' );
+        $this->assertStringContainsString( 'data-template-name="TestTemplate"', $output->getHTML(), 'The spreadsheet should include the template name' );
+        $this->assertStringContainsString( 'data-form-name="TestForm"', $output->getHTML(), 'The spreadsheet should include the form name' );
+    }
+}

--- a/tests/phpunit/integration/specials/PFMultiPageEditTest.php
+++ b/tests/phpunit/integration/specials/PFMultiPageEditTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * Integration tests for the PFMultiPageEdit class.
  *
@@ -27,7 +29,7 @@ class PFMultiPageEditTest extends SpecialPageTestBase {
 	 */
 	protected function newSpecialPage() {
 		// Return an instance of PFMultiPageEdit
-		return new PFMultiPageEdit();
+		return MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage( 'MultiPageEdit' );
 	}
 
 	/**

--- a/tests/phpunit/integration/specials/PFMultiPageEditTest.php
+++ b/tests/phpunit/integration/specials/PFMultiPageEditTest.php
@@ -11,78 +11,78 @@
  */
 class PFMultiPageEditTest extends SpecialPageTestBase {
 
-    protected function setUp(): void {
-        parent::setUp();
-        // Ensure the user has the correct permissions for the test
-        $this->setMwGlobals( 'wgGroupPermissions', [
-            '*' => [ 'multipageedit' => true ],
-            'user' => [ 'multipageedit' => true ]
-        ] );
-    }
+	protected function setUp(): void {
+		parent::setUp();
+		// Ensure the user has the correct permissions for the test
+		$this->setMwGlobals( 'wgGroupPermissions', [
+			'*' => [ 'multipageedit' => true ],
+			'user' => [ 'multipageedit' => true ]
+		] );
+	}
 
-    /**
-     * Create an instance of the special page being tested.
-     *
-     * @return SpecialPage
-     */
-    protected function newSpecialPage() {
-        // Return an instance of PFMultiPageEdit
-        return new PFMultiPageEdit();
-    }
+	/**
+	 * Create an instance of the special page being tested.
+	 *
+	 * @return SpecialPage
+	 */
+	protected function newSpecialPage() {
+		// Return an instance of PFMultiPageEdit
+		return new PFMultiPageEdit();
+	}
 
-    /**
-     * Test executing with template and form parameters.
-     */
-    public function testExecuteWithTemplateAndForm() {
-        // Create a FauxRequest to simulate passing 'template' and 'form' parameters.
-        $params = [
-            'template' => 'TestTemplate',
-            'form' => 'TestForm'
-        ];
-        $request = new FauxRequest( $params );
+	/**
+	 * Test executing with template and form parameters.
+	 */
+	public function testExecuteWithTemplateAndForm() {
+		// Create a FauxRequest to simulate passing 'template' and 'form' parameters.
+		$params = [
+			'template' => 'TestTemplate',
+			'form' => 'TestForm'
+		];
+		$request = new FauxRequest( $params );
 
-        // Set the request in the context using RequestContext.
-        RequestContext::getMain()->setRequest( $request );
+		// Set the request in the context using RequestContext.
+		RequestContext::getMain()->setRequest( $request );
 
-        // Create an instance of PFMultiPageEdit and call execute().
-        $specialPage = $this->newSpecialPage();
-        $specialPage->execute( null );
+		// Create an instance of PFMultiPageEdit and call execute().
+		$specialPage = $this->newSpecialPage();
+		$specialPage->execute( null );
 
-        // Fetch the OutputPage object from the context.
-        $output = RequestContext::getMain()->getOutput();
+		// Fetch the OutputPage object from the context.
+		$output = RequestContext::getMain()->getOutput();
 
-        // Check assertions on the output.
-        $this->assertNotEmpty( $output->getHTML(), 'The page output should not be empty' );
-        $this->assertStringContainsString( 'TestTemplate', $output->getHTML(), 'The template name should appear in the output' );
-    }
+		// Check assertions on the output.
+		$this->assertNotEmpty( $output->getHTML(), 'The page output should not be empty' );
+		$this->assertStringContainsString( 'TestTemplate', $output->getHTML(), 'The template name should appear in the output' );
+	}
 
-    /**
-     * Test the displaySpreadsheet function by mocking a template and form.
-     */
-    public function testDisplaySpreadsheet() {
-        // Create a FauxRequest to simulate passing 'template' and 'form' parameters.
-        $params = [
-            'template' => 'TestTemplate',
-            'form' => 'TestForm'
-        ];
-        $request = new FauxRequest( $params );
-        // Set the request in the context using RequestContext.
-        RequestContext::getMain()->setRequest( $request );
+	/**
+	 * Test the displaySpreadsheet function by mocking a template and form.
+	 */
+	public function testDisplaySpreadsheet() {
+		// Create a FauxRequest to simulate passing 'template' and 'form' parameters.
+		$params = [
+			'template' => 'TestTemplate',
+			'form' => 'TestForm'
+		];
+		$request = new FauxRequest( $params );
+		// Set the request in the context using RequestContext.
+		RequestContext::getMain()->setRequest( $request );
 
-        // Mock the necessary template and form data.
-        $this->editPage( 'Template:TestTemplate', 'Field1|Field2' );
-        $this->editPage( 'Form:TestForm', '{{{for template|TestTemplate}}}' );
+		// Mock the necessary template and form data.
+		$this->editPage( 'Template:TestTemplate', 'Field1|Field2' );
+		$this->editPage( 'Form:TestForm', '{{{for template|TestTemplate}}}' );
 
-        // Create an instance of PFMultiPageEdit and call execute to trigger displaySpreadsheet().
-        $specialPage = $this->newSpecialPage();
-        $specialPage->execute( null );
+		// Create an instance of PFMultiPageEdit and call execute to trigger displaySpreadsheet().
+		$specialPage = $this->newSpecialPage();
+		$specialPage->execute( null );
 
-        // Fetch the OutputPage object from the context.
-        $output = RequestContext::getMain()->getOutput();
+		// Fetch the OutputPage object from the context.
+		$output = RequestContext::getMain()->getOutput();
 
-        // Instead of looking for 'Spreadsheet interface', let's look for part of the actual output.
-        $this->assertStringContainsString( 'class="pfSpreadsheet"', $output->getHTML(), 'The spreadsheet interface should be displayed' );
-        $this->assertStringContainsString( 'data-template-name="TestTemplate"', $output->getHTML(), 'The spreadsheet should include the template name' );
-        $this->assertStringContainsString( 'data-form-name="TestForm"', $output->getHTML(), 'The spreadsheet should include the form name' );
-    }
+		// Instead of looking for 'Spreadsheet interface', let's look for part of the actual output.
+		$this->assertStringContainsString( 'class="pfSpreadsheet"', $output->getHTML(), 'The spreadsheet interface should be displayed' );
+		$this->assertStringContainsString( 'data-template-name="TestTemplate"', $output->getHTML(), 'The spreadsheet should include the template name' );
+		$this->assertStringContainsString( 'data-form-name="TestForm"', $output->getHTML(), 'The spreadsheet should include the form name' );
+	}
 }

--- a/tests/phpunit/integration/specials/PFMultiPageEditTest.php
+++ b/tests/phpunit/integration/specials/PFMultiPageEditTest.php
@@ -9,7 +9,7 @@
  *
  * @author gesinn-it-ilm
  */
-class PFMultiPageEditTest extends MediaWikiIntegrationTestCase {
+class PFMultiPageEditTest extends SpecialPageTestBase {
 
     protected function setUp(): void {
         parent::setUp();
@@ -18,6 +18,16 @@ class PFMultiPageEditTest extends MediaWikiIntegrationTestCase {
             '*' => [ 'multipageedit' => true ],
             'user' => [ 'multipageedit' => true ]
         ] );
+    }
+
+    /**
+     * Create an instance of the special page being tested.
+     *
+     * @return SpecialPage
+     */
+    protected function newSpecialPage() {
+        // Return an instance of PFMultiPageEdit
+        return new PFMultiPageEdit();
     }
 
     /**
@@ -35,7 +45,7 @@ class PFMultiPageEditTest extends MediaWikiIntegrationTestCase {
         RequestContext::getMain()->setRequest( $request );
 
         // Create an instance of PFMultiPageEdit and call execute().
-        $specialPage = new PFMultiPageEdit();
+        $specialPage = $this->newSpecialPage();
         $specialPage->execute( null );
 
         // Fetch the OutputPage object from the context.
@@ -64,7 +74,7 @@ class PFMultiPageEditTest extends MediaWikiIntegrationTestCase {
         $this->editPage( 'Form:TestForm', '{{{for template|TestTemplate}}}' );
 
         // Create an instance of PFMultiPageEdit and call execute to trigger displaySpreadsheet().
-        $specialPage = new PFMultiPageEdit();
+        $specialPage = $this->newSpecialPage();
         $specialPage->execute( null );
 
         // Fetch the OutputPage object from the context.

--- a/tests/phpunit/integration/specials/PFRunQueryTest.php
+++ b/tests/phpunit/integration/specials/PFRunQueryTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * Integration test class for the PFRunQuery special page.
+ * This uses MediaWikiIntegrationTestCase, designed for testing in the MediaWiki framework.
+ *
+ * @covers \PFRunQuery
+ * 
+ * @group Database
+ *
+ * @author gesinn-it-ilm
+ */
+class PFRunQueryTest extends MediaWikiIntegrationTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        if ( !defined( 'PF_NS_FORM' ) ) {
+            define( 'PF_NS_FORM', 106 );
+        }
+    }
+
+    public function testExecuteWithoutQuery() {
+        // Create a special page instance
+        $specialPage = new PFRunQuery();
+        
+        // Create a faux request object with no form query
+        $request = new FauxRequest(
+            [
+                'form' => ''
+            ],
+            true
+        );
+
+        // Create a RequestContext and set the faux request
+        $context = new RequestContext();
+        $context->setRequest( $request );
+
+        // Inject the context into the special page
+        $specialPage->setContext( $context );
+
+        // Capture the output
+        $outputPage = $context->getOutput();
+        
+        // Execute the special page
+        $specialPage->execute( '' );
+
+        // Capture the output after execution
+        $output = $outputPage->getHTML();
+        
+        // Check if the output contains an error message
+        $this->assertStringContainsString( 'error', $output );
+    }
+
+    public function testExecuteWithNonexistentForm() {
+        // Create a special page instance
+        $specialPage = new PFRunQuery();
+
+        // Create a request object with a non-existent form name
+        $request = new FauxRequest(
+            [
+                'form' => 'NonExistentForm'
+            ]
+        );
+
+        // Create a RequestContext and set the faux request
+        $context = new RequestContext();
+        $context->setRequest( $request );
+
+        // Inject the context into the special page
+        $specialPage->setContext( $context );
+
+        // Capture the output
+        $outputPage = $context->getOutput();
+        
+        // Execute the special page
+        $specialPage->execute( '' );
+
+        // Capture the output after execution
+        $output = $outputPage->getHTML();
+
+        // Check if the output contains part of the error message
+        $this->assertStringContainsString(
+            'Error: No form was found on page',
+            $output
+        );
+    }
+
+    public function testExecuteWithValidForm() {
+        // Create a special page instance
+        $specialPage = new PFRunQuery();
+
+        // Mock the request with a valid form
+        $request = new FauxRequest(
+            [
+                'form' => 'ValidForm'
+            ]
+        );
+
+        $context = new RequestContext();
+        $context->setRequest( $request );
+
+        // Mock form title and form content
+        $formTitle = Title::newFromText( 'ValidForm', PF_NS_FORM );
+        $this->insertPage( $formTitle, 'Form content here' );
+
+        // Inject the context into the special page
+        $specialPage->setContext( $context );
+
+        // Capture the output
+        $outputPage = $context->getOutput();
+
+        // Execute the special page
+        $specialPage->execute( 'ValidForm' );
+
+        // Capture the output after execution
+        $output = $outputPage->getHTML();
+
+        $this->assertStringContainsString( 'Form content here', $output );
+    }
+
+    public function testSubmitFormQuery() {
+        // Create a special page instance
+        $specialPage = new PFRunQuery();
+
+        // Mock the request with valid form data and a _run parameter
+        $request = new FauxRequest(
+            [
+                'form' => 'ValidForm',
+                '_run' => 'true',
+                'wpTextbox1' => 'Some content for query'
+            ]
+        );
+
+        $context = new RequestContext();
+        $context->setRequest( $request );
+
+        // Inject the context into the special page
+        $specialPage->setContext( $context );
+
+        // Mock form title and form content
+        $formTitle = Title::newFromText( 'ValidForm', PF_NS_FORM );
+        $this->insertPage( $formTitle, 'Form content here' );
+
+        // Capture the output
+        $outputPage = $context->getOutput();
+
+        // Execute the special page
+        $specialPage->execute( 'ValidForm' );
+
+        // Capture the output after execution
+        $output = $outputPage->getHTML();
+
+        $this->assertStringContainsString( 'Some content for query', $output );
+    }
+}

--- a/tests/phpunit/integration/specials/PFRunQueryTest.php
+++ b/tests/phpunit/integration/specials/PFRunQueryTest.php
@@ -5,7 +5,7 @@
  * This uses MediaWikiIntegrationTestCase, designed for testing in the MediaWiki framework.
  *
  * @covers \PFRunQuery
- * 
+ *
  * @group Database
  *
  * @author gesinn-it-ilm
@@ -23,7 +23,7 @@ class PFRunQueryTest extends MediaWikiIntegrationTestCase {
 	public function testExecuteWithoutQuery() {
 		// Create a special page instance
 		$specialPage = new PFRunQuery();
-		
+
 		// Create a faux request object with no form query
 		$request = new FauxRequest(
 			[
@@ -41,13 +41,13 @@ class PFRunQueryTest extends MediaWikiIntegrationTestCase {
 
 		// Capture the output
 		$outputPage = $context->getOutput();
-		
+
 		// Execute the special page
 		$specialPage->execute( '' );
 
 		// Capture the output after execution
 		$output = $outputPage->getHTML();
-		
+
 		// Check if the output contains an error message
 		$this->assertStringContainsString( 'error', $output );
 	}
@@ -72,7 +72,7 @@ class PFRunQueryTest extends MediaWikiIntegrationTestCase {
 
 		// Capture the output
 		$outputPage = $context->getOutput();
-		
+
 		// Execute the special page
 		$specialPage->execute( '' );
 

--- a/tests/phpunit/integration/specials/PFRunQueryTest.php
+++ b/tests/phpunit/integration/specials/PFRunQueryTest.php
@@ -53,6 +53,12 @@ class PFRunQueryTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testExecuteWithNonexistentForm() {
+		if ( version_compare( MW_VERSION, '1.39', '>' ) ) {
+			// Mock the hook for DisplayTitle to prevent the error
+			$this->overrideConfigValue( 'Hooks', [
+				'PageProps' => []
+			] );
+		}
 		// Create a special page instance
 		$specialPage = new PFRunQuery();
 

--- a/tests/phpunit/integration/specials/PFRunQueryTest.php
+++ b/tests/phpunit/integration/specials/PFRunQueryTest.php
@@ -21,14 +21,14 @@ class PFRunQueryTest extends SpecialPageTestBase {
 	}
 
 	/**
-     * Create an instance of the special page being tested.
-     *
-     * @return SpecialPage
-     */
-    protected function newSpecialPage() {
-        // Return an instance of PFRunQuery
-        return new PFRunQuery();
-    }
+	 * Create an instance of the special page being tested.
+	 *
+	 * @return SpecialPage
+	 */
+	protected function newSpecialPage() {
+		// Return an instance of PFRunQuery
+		return new PFRunQuery();
+	}
 
 	public function testExecuteWithoutQuery() {
 		// Create a special page instance

--- a/tests/phpunit/integration/specials/PFRunQueryTest.php
+++ b/tests/phpunit/integration/specials/PFRunQueryTest.php
@@ -12,145 +12,145 @@
  */
 class PFRunQueryTest extends MediaWikiIntegrationTestCase {
 
-    protected function setUp(): void {
-        parent::setUp();
+	protected function setUp(): void {
+		parent::setUp();
 
-        if ( !defined( 'PF_NS_FORM' ) ) {
-            define( 'PF_NS_FORM', 106 );
-        }
-    }
+		if ( !defined( 'PF_NS_FORM' ) ) {
+			define( 'PF_NS_FORM', 106 );
+		}
+	}
 
-    public function testExecuteWithoutQuery() {
-        // Create a special page instance
-        $specialPage = new PFRunQuery();
-        
-        // Create a faux request object with no form query
-        $request = new FauxRequest(
-            [
-                'form' => ''
-            ],
-            true
-        );
+	public function testExecuteWithoutQuery() {
+		// Create a special page instance
+		$specialPage = new PFRunQuery();
+		
+		// Create a faux request object with no form query
+		$request = new FauxRequest(
+			[
+				'form' => ''
+			],
+			true
+		);
 
-        // Create a RequestContext and set the faux request
-        $context = new RequestContext();
-        $context->setRequest( $request );
+		// Create a RequestContext and set the faux request
+		$context = new RequestContext();
+		$context->setRequest( $request );
 
-        // Inject the context into the special page
-        $specialPage->setContext( $context );
+		// Inject the context into the special page
+		$specialPage->setContext( $context );
 
-        // Capture the output
-        $outputPage = $context->getOutput();
-        
-        // Execute the special page
-        $specialPage->execute( '' );
+		// Capture the output
+		$outputPage = $context->getOutput();
+		
+		// Execute the special page
+		$specialPage->execute( '' );
 
-        // Capture the output after execution
-        $output = $outputPage->getHTML();
-        
-        // Check if the output contains an error message
-        $this->assertStringContainsString( 'error', $output );
-    }
+		// Capture the output after execution
+		$output = $outputPage->getHTML();
+		
+		// Check if the output contains an error message
+		$this->assertStringContainsString( 'error', $output );
+	}
 
-    public function testExecuteWithNonexistentForm() {
-        // Create a special page instance
-        $specialPage = new PFRunQuery();
+	public function testExecuteWithNonexistentForm() {
+		// Create a special page instance
+		$specialPage = new PFRunQuery();
 
-        // Create a request object with a non-existent form name
-        $request = new FauxRequest(
-            [
-                'form' => 'NonExistentForm'
-            ]
-        );
+		// Create a request object with a non-existent form name
+		$request = new FauxRequest(
+			[
+				'form' => 'NonExistentForm'
+			]
+		);
 
-        // Create a RequestContext and set the faux request
-        $context = new RequestContext();
-        $context->setRequest( $request );
+		// Create a RequestContext and set the faux request
+		$context = new RequestContext();
+		$context->setRequest( $request );
 
-        // Inject the context into the special page
-        $specialPage->setContext( $context );
+		// Inject the context into the special page
+		$specialPage->setContext( $context );
 
-        // Capture the output
-        $outputPage = $context->getOutput();
-        
-        // Execute the special page
-        $specialPage->execute( '' );
+		// Capture the output
+		$outputPage = $context->getOutput();
+		
+		// Execute the special page
+		$specialPage->execute( '' );
 
-        // Capture the output after execution
-        $output = $outputPage->getHTML();
+		// Capture the output after execution
+		$output = $outputPage->getHTML();
 
-        // Check if the output contains part of the error message
-        $this->assertStringContainsString(
-            'Error: No form was found on page',
-            $output
-        );
-    }
+		// Check if the output contains part of the error message
+		$this->assertStringContainsString(
+			'Error: No form was found on page',
+			$output
+		);
+	}
 
-    public function testExecuteWithValidForm() {
-        // Create a special page instance
-        $specialPage = new PFRunQuery();
+	public function testExecuteWithValidForm() {
+		// Create a special page instance
+		$specialPage = new PFRunQuery();
 
-        // Mock the request with a valid form
-        $request = new FauxRequest(
-            [
-                'form' => 'ValidForm'
-            ]
-        );
+		// Mock the request with a valid form
+		$request = new FauxRequest(
+			[
+				'form' => 'ValidForm'
+			]
+		);
 
-        $context = new RequestContext();
-        $context->setRequest( $request );
+		$context = new RequestContext();
+		$context->setRequest( $request );
 
-        // Mock form title and form content
-        $formTitle = Title::newFromText( 'ValidForm', PF_NS_FORM );
-        $this->insertPage( $formTitle, 'Form content here' );
+		// Mock form title and form content
+		$formTitle = Title::newFromText( 'ValidForm', PF_NS_FORM );
+		$this->insertPage( $formTitle, 'Form content here' );
 
-        // Inject the context into the special page
-        $specialPage->setContext( $context );
+		// Inject the context into the special page
+		$specialPage->setContext( $context );
 
-        // Capture the output
-        $outputPage = $context->getOutput();
+		// Capture the output
+		$outputPage = $context->getOutput();
 
-        // Execute the special page
-        $specialPage->execute( 'ValidForm' );
+		// Execute the special page
+		$specialPage->execute( 'ValidForm' );
 
-        // Capture the output after execution
-        $output = $outputPage->getHTML();
+		// Capture the output after execution
+		$output = $outputPage->getHTML();
 
-        $this->assertStringContainsString( 'Form content here', $output );
-    }
+		$this->assertStringContainsString( 'Form content here', $output );
+	}
 
-    public function testSubmitFormQuery() {
-        // Create a special page instance
-        $specialPage = new PFRunQuery();
+	public function testSubmitFormQuery() {
+		// Create a special page instance
+		$specialPage = new PFRunQuery();
 
-        // Mock the request with valid form data and a _run parameter
-        $request = new FauxRequest(
-            [
-                'form' => 'ValidForm',
-                '_run' => 'true',
-                'wpTextbox1' => 'Some content for query'
-            ]
-        );
+		// Mock the request with valid form data and a _run parameter
+		$request = new FauxRequest(
+			[
+				'form' => 'ValidForm',
+				'_run' => 'true',
+				'wpTextbox1' => 'Some content for query'
+			]
+		);
 
-        $context = new RequestContext();
-        $context->setRequest( $request );
+		$context = new RequestContext();
+		$context->setRequest( $request );
 
-        // Inject the context into the special page
-        $specialPage->setContext( $context );
+		// Inject the context into the special page
+		$specialPage->setContext( $context );
 
-        // Mock form title and form content
-        $formTitle = Title::newFromText( 'ValidForm', PF_NS_FORM );
-        $this->insertPage( $formTitle, 'Form content here' );
+		// Mock form title and form content
+		$formTitle = Title::newFromText( 'ValidForm', PF_NS_FORM );
+		$this->insertPage( $formTitle, 'Form content here' );
 
-        // Capture the output
-        $outputPage = $context->getOutput();
+		// Capture the output
+		$outputPage = $context->getOutput();
 
-        // Execute the special page
-        $specialPage->execute( 'ValidForm' );
+		// Execute the special page
+		$specialPage->execute( 'ValidForm' );
 
-        // Capture the output after execution
-        $output = $outputPage->getHTML();
+		// Capture the output after execution
+		$output = $outputPage->getHTML();
 
-        $this->assertStringContainsString( 'Some content for query', $output );
-    }
+		$this->assertStringContainsString( 'Some content for query', $output );
+	}
 }

--- a/tests/phpunit/integration/specials/PFRunQueryTest.php
+++ b/tests/phpunit/integration/specials/PFRunQueryTest.php
@@ -10,7 +10,7 @@
  *
  * @author gesinn-it-ilm
  */
-class PFRunQueryTest extends MediaWikiIntegrationTestCase {
+class PFRunQueryTest extends SpecialPageTestBase {
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -20,9 +20,19 @@ class PFRunQueryTest extends MediaWikiIntegrationTestCase {
 		}
 	}
 
+	/**
+     * Create an instance of the special page being tested.
+     *
+     * @return SpecialPage
+     */
+    protected function newSpecialPage() {
+        // Return an instance of PFRunQuery
+        return new PFRunQuery();
+    }
+
 	public function testExecuteWithoutQuery() {
 		// Create a special page instance
-		$specialPage = new PFRunQuery();
+		$specialPage = $this->newSpecialPage();
 
 		// Create a faux request object with no form query
 		$request = new FauxRequest(
@@ -60,7 +70,7 @@ class PFRunQueryTest extends MediaWikiIntegrationTestCase {
 			] );
 		}
 		// Create a special page instance
-		$specialPage = new PFRunQuery();
+		$specialPage = $this->newSpecialPage();
 
 		// Create a request object with a non-existent form name
 		$request = new FauxRequest(
@@ -94,7 +104,7 @@ class PFRunQueryTest extends MediaWikiIntegrationTestCase {
 
 	public function testExecuteWithValidForm() {
 		// Create a special page instance
-		$specialPage = new PFRunQuery();
+		$specialPage = $this->newSpecialPage();
 
 		// Mock the request with a valid form
 		$request = new FauxRequest(
@@ -127,7 +137,7 @@ class PFRunQueryTest extends MediaWikiIntegrationTestCase {
 
 	public function testSubmitFormQuery() {
 		// Create a special page instance
-		$specialPage = new PFRunQuery();
+		$specialPage = $this->newSpecialPage();
 
 		// Mock the request with valid form data and a _run parameter
 		$request = new FauxRequest(

--- a/tests/phpunit/integration/specials/PFRunQueryTest.php
+++ b/tests/phpunit/integration/specials/PFRunQueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * Integration test class for the PFRunQuery special page.
  * This uses MediaWikiIntegrationTestCase, designed for testing in the MediaWiki framework.
@@ -27,7 +29,7 @@ class PFRunQueryTest extends SpecialPageTestBase {
 	 */
 	protected function newSpecialPage() {
 		// Return an instance of PFRunQuery
-		return new PFRunQuery();
+		return MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage( 'RunQuery' );
 	}
 
 	public function testExecuteWithoutQuery() {


### PR DESCRIPTION
This PR is opened due to the issue #68.

This PR contains:

- more tests for SpecialPages;
- refactored existing tests;
- use [SpecialPageTestBase](https://github.com/wikimedia/mediawiki/blob/master/tests/phpunit/includes/specials/SpecialPageTestBase.php) instead of MediaWikiIntegrationTestCase;
- update build (CI) - add matrix for MW 1.40;
- fix matrix for MW 1.39
- clear some of the reported sniffs