### PR TITLE
Issue 85 - add JSONScript tests for form inputs

### DIFF
--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-checkbox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-checkbox.json
@@ -44,4 +44,3 @@
 		"debug": false
 	}
 }
-  

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-checkbox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-checkbox.json
@@ -23,12 +23,11 @@
 			},
 			"assert-output": {
             "to-contain": [
-                    "<span id='input_1' class=' oo-ui-widget oo-ui-widget-enabled oo-ui-inputWidget oo-ui-checkboxInputWidget'>",
                     "<input type='checkbox'",
                     "tabindex='1'",
                     "name='standard input[Checkbox][value]'",
                     "class='oo-ui-inputWidget-input' />",
-                    "<span class='oo-ui-checkboxInputWidget-checkIcon oo-ui-widget oo-ui-widget-enabled oo-ui-iconElement-icon oo-ui-icon-check oo-ui-iconElement oo-ui-labelElement-invisible oo-ui-iconWidget oo-ui-image-invert'>"
+					"standard input[Checkbox][is_checkbox]"
                 ]
 		    }
 	    }

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-checkbox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-checkbox.json
@@ -34,9 +34,7 @@
 	    }
 	],
 	"settings": {
-		"wgLang": "en",
-		"wgPageFormsTabIndex": 2,
-		"wgPageFormsFieldNum": 1
+		"wgLang": "en"
 	},
 	"meta": {
 		"version": "2",

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-checkbox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-checkbox.json
@@ -1,0 +1,47 @@
+{
+	"description": "form input checkbox",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Boolean Property",
+			"contents": "[[Has type::Boolean]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Checkbox without other parameters",
+			"contents": "{{{field|Checkbox|input type=checkbox}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Checkbox without other parameters",
+			"special-page": {
+			"page": "FormEdit",
+			"query-parameters": "Checkbox without other parameters/01",
+			"request-parameters": {}
+			},
+			"assert-output": {
+            "to-contain": [
+                    "<span id='input_1' class=' oo-ui-widget oo-ui-widget-enabled oo-ui-inputWidget oo-ui-checkboxInputWidget'>",
+                    "<input type='checkbox'",
+                    "tabindex='1'",
+                    "name='standard input[Checkbox][value]'",
+                    "class='oo-ui-inputWidget-input' />",
+                    "<span class='oo-ui-checkboxInputWidget-checkIcon oo-ui-widget oo-ui-widget-enabled oo-ui-iconElement-icon oo-ui-icon-check oo-ui-iconElement oo-ui-labelElement-invisible oo-ui-iconWidget oo-ui-image-invert'>"
+                ]
+		    }
+	    }
+	],
+	"settings": {
+		"wgLang": "en",
+		"wgPageFormsTabIndex": 2,
+		"wgPageFormsFieldNum": 1
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}
+  

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-combobox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-combobox.json
@@ -25,7 +25,7 @@
 				"to-contain": [
 					"<span class=\"comboboxSpan\" data-input-type=\"combobox\">",
 					"<option value=\"\"></option>",
-                    "<option selected=\"\"></option>"   
+                    "<option selected=\"\"></option>"
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-combobox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-combobox.json
@@ -24,6 +24,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<span class=\"comboboxSpan\" data-input-type=\"combobox\">",
+					"<select id=\"input_1\" name=\"standard input[Combobox]\" class=\"pfComboBox\" tabindex=\"1\" autocompletesettings=\"\" data-size=\"210\" style=\"width:210px\">",
 					"<option value=\"\"></option>",
                     "<option selected=\"\"></option>"
 				]

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-combobox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-combobox.json
@@ -1,0 +1,43 @@
+{
+	"description": "form input combobox",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "String Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Combobox without values",
+			"contents": "{{{field|Combobox|input type=combobox}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Combobox without values",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Combobox without values/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"comboboxSpan\" data-input-type=\"combobox\">",
+					"<option value=\"\"></option>",
+                    "<option selected=\"\"></option>"   
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en",
+		"wgPageFormsTabIndex": 2,
+		"wgPageFormsFieldNum": 1
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-combobox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-combobox.json
@@ -3,7 +3,7 @@
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
-			"page": "String Property",
+			"page": "Text Property",
 			"contents": "[[Has type::Text]]"
 		},
 		{
@@ -31,9 +31,7 @@
 		}
 	],
 	"settings": {
-		"wgLang": "en",
-		"wgPageFormsTabIndex": 2,
-		"wgPageFormsFieldNum": 1
+		"wgLang": "en"
 	},
 	"meta": {
 		"version": "2",

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-date.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-date.json
@@ -1,0 +1,45 @@
+{
+	"description": "form input date",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Date without other parameters",
+			"contents": "{{{field|Date|input type=date}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Date without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Date without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"dateInput\">",
+                    "dayInput",
+                    "standard input[Date][day]",
+                    "monthInput",
+                    "standard input[Date][month]",
+                    "yearInput",
+                    "standard input[Date][year]"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-datepicker.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-datepicker.json
@@ -1,0 +1,41 @@
+{
+	"description": "form input datepicker",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Datepicker with values",
+			"contents": "{{{field|Datepicker|input type=datepicker}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Datepicker with values",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Datepicker with values/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<input type='date' tabindex='0' name='standard input[Datepicker]' value='' placeholder='YYYY-MM-DD' class='oo-ui-inputWidget-input' />"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en",
+		"wgPageFormsTabIndex": 2,
+		"wgPageFormsFieldNum": 1
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-datepicker.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-datepicker.json
@@ -29,9 +29,7 @@
 		}
 	],
 	"settings": {
-		"wgLang": "en",
-		"wgPageFormsTabIndex": 2,
-		"wgPageFormsFieldNum": 1
+		"wgLang": "en"
 	},
 	"meta": {
 		"version": "2",

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-datepicker.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-datepicker.json
@@ -23,7 +23,10 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<input type='date' tabindex='0' name='standard input[Datepicker]' value='' placeholder='YYYY-MM-DD' class='oo-ui-inputWidget-input' />"
+					"<div class=\"pfPickerWrapper\">",
+					"pfDatePicker",
+					"standard input[Datepicker]",
+					"placeholder='YYYY-MM-DD'"
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-datetime.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-datetime.json
@@ -1,0 +1,51 @@
+{
+	"description": "form input datetime",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Datetime without other parameters",
+			"contents": "{{{field|Datetime|input type=datetime}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Datetime without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Datetime without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"dateTimeInput\">",
+                    "dayInput",
+                    "standard input[Datetime][day]",
+                    "monthInput",
+                    "standard input[Datetime][month]",
+                    "yearInput",
+                    "standard input[Datetime][year]",
+                    "hoursInput",
+                    "standard input[Datetime][hour]",
+                    "minutesInput",
+                    "standard input[Datetime][minute]",
+                    "secondsInput",
+                    "standard input[Datetime][second]"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-datetimepicker.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-datetimepicker.json
@@ -1,0 +1,42 @@
+{
+	"description": "form input datetimepicker",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Datetimepicker with values",
+			"contents": "{{{field|Datetimepicker|input type=datetimepicker}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Datetimepicker with values",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Datetimepicker with values/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfPickerWrapper\">",
+                    "'pfDateTimePicker",
+                    "standard input[Datetimepicker]",
+					"<label for=\"input_1\" class=\"oo-ui-labelWidget oo-ui-inline-help\" style=\"margin-top: 4px;\">Time should be entered in 24-hour format.</label>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-dropdown.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-dropdown.json
@@ -1,0 +1,40 @@
+{
+	"description": "form input dropdown",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Dropdown without other parameters",
+			"contents": "{{{field|Dropdown|input type=dropdown}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Dropdown without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Dropdown without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"createboxInput",
+					"standard input[Dropdown]"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-googlemaps.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-googlemaps.json
@@ -1,0 +1,43 @@
+{
+	"description": "form input googlemaps",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Googlemaps without other parameters",
+			"contents": "{{{field|Googlemaps|input type=googlemaps}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Googlemaps without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Googlemaps without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+                    "<div class=\"pfGoogleMapsInput\">",
+                    "placeholder='Enter address here'",
+                    "<input tabindex=\"3\" class=\"pfCoordsInput\" name=\"standard input[Googlemaps]\" size=\"40\"/>",
+                    "<span class='oo-ui-labelElement-label'>Calculate coordinates using address</span>",
+					"<div class=\"pfMapCanvas\" id=\"pfMapCanvas1\" style=\"height: 500px; width: 500px;\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-leaflet.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-leaflet.json
@@ -1,0 +1,43 @@
+{
+	"description": "form input leaflet",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Leaflet without other parameters",
+			"contents": "{{{field|Leaflet|input type=leaflet}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Leaflet without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Leaflet without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+                    "<div class=\"pfLeafletInput\">",
+                    "placeholder='Enter address here'",
+                    "<input tabindex=\"3\" class=\"pfCoordsInput\" name=\"standard input[Leaflet]\" size=\"40\"/>",
+                    "<span class='oo-ui-labelElement-label'>Calculate coordinates using address</span>",
+					"<div class=\"pfMapCanvas\" id=\"pfMapCanvas1\" style=\"height: 500px; width: 500px;\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-listbox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-listbox.json
@@ -1,0 +1,39 @@
+{
+	"description": "form input listbox",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Listbox without other parameters",
+			"contents": "{{{field|Listbox|input type=listbox}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Listbox without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Listbox without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<select id=\"input_1\" tabindex=\"1\" name=\"standard input[Listbox][]\" class=\"createboxInput pfShowIfSelected\" multiple=\"\"></select>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-openlayers.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-openlayers.json
@@ -1,0 +1,44 @@
+{
+	"description": "form input openlayers",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Openlayers without other parameters",
+			"contents": "{{{field|Openlayers|input type=openlayers}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Openlayers without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Openlayers without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfOpenLayersInput\">",
+					"<div class='pfAddressInput oo-ui-widget oo-ui-widget-enabled oo-ui-inputWidget oo-ui-textInputWidget oo-ui-textInputWidget-type-text oo-ui-textInputWidget-php'>",
+					"placeholder='Enter address here'",
+					"pfLookUpAddress",
+					"<span class='oo-ui-labelElement-label'>Calculate coordinates using address</span>",
+					"<input tabindex=\"3\" class=\"pfCoordsInput\" name=\"standard input[Openlayers]\" size=\"40\"/>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-openlayers.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-openlayers.json
@@ -24,7 +24,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<div class=\"pfOpenLayersInput\">",
-					"<div class='pfAddressInput oo-ui-widget oo-ui-widget-enabled oo-ui-inputWidget oo-ui-textInputWidget oo-ui-textInputWidget-type-text oo-ui-textInputWidget-php'>",
+					"pfAddressInput",
 					"placeholder='Enter address here'",
 					"pfLookUpAddress",
 					"<span class='oo-ui-labelElement-label'>Calculate coordinates using address</span>",

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-rating.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-rating.json
@@ -1,0 +1,39 @@
+{
+	"description": "form input rating",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Rating without other parameters",
+			"contents": "{{{field|Rating|input type=rating}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Rating without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Rating without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfRating\" data-starwidth=\"24px\" data-numstars=\"5\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-regexp.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-regexp.json
@@ -1,0 +1,40 @@
+{
+	"description": "form input regexp",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Regexp accepting only letters, numbers and spaces",
+			"contents": "{{{field|Regexp|input type=regexp|regexp=/^[0-9A-Za-z ]+$/}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Regexp accepting only letters, numbers and spaces",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Regexp accepting only letters, numbers and spaces/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"createboxInput",
+                    "standard input[Regexp]"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-text.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-text.json
@@ -1,0 +1,39 @@
+{
+	"description": "form input text",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Text input without other parameters",
+			"contents": "{{{field|Text|input type=text}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Text input without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Text input without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<input id=\"input_1\" tabindex=\"1\" class=\"createboxInput\" size=\"35\" name=\"standard input[Text]\"/>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-textarea.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-textarea.json
@@ -15,6 +15,11 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Textarea input with rows param",
 			"contents": "{{{field|Textarea|input type=textarea|rows=10}}}"
+		},
+        {
+			"namespace": "PF_NS_FORM",
+			"page": "Textarea input with placeholder param",
+			"contents": "{{{field|Textarea|input type=textarea|placeholder=add text here}}}"
 		}
 	],
 	"tests": [
@@ -43,6 +48,20 @@
 			"assert-output": {
 				"to-contain": [
 					"<textarea tabindex=\"1\" name=\"standard input[Textarea]\" id=\"input_1\" class=\"createboxInput\" rows=\"10\" cols=\"90\" style=\"width: 100%\"></textarea>"
+				]
+			}
+		},
+        {
+			"type": "special",
+			"about": "Textarea input with placeholder param",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Textarea input with placeholder param/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<textarea tabindex=\"1\" name=\"standard input[Textarea]\" id=\"input_1\" class=\"createboxInput\" rows=\"5\" cols=\"90\" style=\"width: 100%\" placeholder=\"add text here\">"
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-textarea.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-textarea.json
@@ -1,0 +1,58 @@
+{
+	"description": "form input textarea",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Textarea input without other parameters",
+			"contents": "{{{field|Textarea|input type=textarea}}}"
+		},
+        {
+			"namespace": "PF_NS_FORM",
+			"page": "Textarea input with rows param",
+			"contents": "{{{field|Textarea|input type=textarea|rows=10}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Textarea input without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Textarea input without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<textarea tabindex=\"1\" name=\"standard input[Textarea]\" id=\"input_1\" class=\"createboxInput\" rows=\"5\" cols=\"90\" style=\"width: 100%\"></textarea>"
+				]
+			}
+		},
+        {
+			"type": "special",
+			"about": "Textarea input with rows param",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Textarea input with rows param/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<textarea tabindex=\"1\" name=\"standard input[Textarea]\" id=\"input_1\" class=\"createboxInput\" rows=\"10\" cols=\"90\" style=\"width: 100%\"></textarea>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-textareaautocomplete.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-textareaautocomplete.json
@@ -1,0 +1,39 @@
+{
+	"description": "form input textarea with autocomplete (aliases for \"combobox\" or \"tokens\")",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Textarea with autocomplete input without other parameters",
+			"contents": "{{{field|TextareaWithAutocomplete|input type=textarea with autocomplete}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Textarea with autocomplete input without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Textarea with autocomplete input without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<select id=\"input_1\" name=\"standard input[TextareaWithAutocomplete]\" class=\"pfComboBox\" tabindex=\"1\" autocompletesettings=\"\" data-size=\"210\" style=\"width:210px\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-timepicker.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-timepicker.json
@@ -1,0 +1,39 @@
+{
+	"description": "form input timepicker",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Timepicker without other parameters",
+			"contents": "{{{field|Timepicker|input type=timepicker}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Timepicker without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Timepicker without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<input id=\"input_1\" tabindex=\"1\" class=\"createboxInput\" size=\"35\" name=\"standard input[Timepicker]\"/>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-tokens.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-tokens.json
@@ -1,0 +1,39 @@
+{
+	"description": "form input tokens",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Tokens without other parameters",
+			"contents": "{{{field|Tokens|input type=tokens}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Tokens without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Tokens without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<select id=\"input_1\" name=\"standard input[Tokens][]\" class=\"pfTokens createboxInput\" style=\"width:450px\" multiple=\"\" size=\"1\" data-size=\"450px\" tabindex=\"1\" autocompletesettings=\",list,,\"></select>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-tree.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-tree.json
@@ -1,0 +1,43 @@
+{
+	"description": "form input tree",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Tree with structure params",
+			"contents": "{{{field|Tree|input type=tree|structure=*Test**Test1**Test2}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Tree with structure params",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Tree with structure params/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfTreeInputWrapper\">",
+					"pfTreeInput",
+					"standard input[Tree]treeinput",
+					"<input type='hidden' class='PFTree_data' name='standard input[Tree]'>",
+					"data=\"[{&quot;level&quot;:1,&quot;text&quot;:&quot;Test**Test1**Test2&quot;,&quot;node_id&quot;:0,&quot;state&quot;:{&quot;opened&quot;:true}}]"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-year.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-year.json
@@ -1,0 +1,41 @@
+{
+	"description": "form input year",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Text Property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Year without other parameters",
+			"contents": "{{{field|Year|input type=year}}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "Year without other parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Year without other parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"inputSpan\" data-input-type=\"text\">",
+					"createboxInput",
+					"standard input[Year]"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/integration/includes/PF_TemplateInFormTest.php
+++ b/tests/phpunit/integration/includes/PF_TemplateInFormTest.php
@@ -112,7 +112,9 @@ class PFTemplateInFormTest extends TestCase {
 		$template = new PFTemplateInForm();
 		$template->setTemplateName( 'My Template' );
 		$template->setAllowsMultiple( true );
-		$template->setInstanceNum( 1 );
+		if ( version_compare( MW_VERSION, '1.39', '>=' ) ) {
+			$template->setInstanceNum( 1 );
+		}
 
 		$template->setFieldValuesFromSubmit();
 


### PR DESCRIPTION
This PR is related to the issue #85.

This PR contains:

- added basic JSONScript tests for PF form inputs
- coverage increased from 19% to 24%
- added tests will be updated with more test cases as a part of another PR