### PR TITLE
Issue 87 - add support for MW 1.41

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,15 @@ jobs:
             database_image: "mysql:8"
             coverage: false
             experimental: false
+          - mediawiki_version: '1.41'
+            smw_version: dev-master
+            php_version: 8.1
+            dt_version: 4.0.3
+            ps_version: 0.9.1
+            database_type: mysql
+            database_image: "mysql:8"
+            coverage: false
+            experimental: false
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/includes/PF_AutoeditAPI.php
+++ b/includes/PF_AutoeditAPI.php
@@ -221,7 +221,7 @@ class PFAutoeditAPI extends ApiBase {
 			$this->mOptions['target'] = $target->getPrefixedText();
 		}
 
-		Hooks::run( 'PageForms::SetTargetName', [ &$this->mOptions['target'], $hookQuery ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::SetTargetName', [ &$this->mOptions['target'], $hookQuery ] );
 
 		// set html return status. If all goes well, this will not be changed
 		$this->mStatus = 200;
@@ -380,13 +380,13 @@ class PFAutoeditAPI extends ApiBase {
 		$out = $this->getOutput();
 		$previewOutput = $editor->getPreviewText();
 
-		Hooks::run( 'EditPage::showEditForm:initial', [ $editor, $out ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'EditPage::showEditForm:initial', [ $editor, $out ] );
 
 		$out->setRobotPolicy( 'noindex,nofollow' );
 
 		// This hook seems slightly odd here, but makes things more
 		// consistent for extensions.
-		Hooks::run( 'OutputPageBeforeHTML', [ $out, $previewOutput ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'OutputPageBeforeHTML', [ $out, $previewOutput ] );
 
 		$out->addHTML( Html::rawElement( 'div', [ 'id' => 'wikiPreview' ], $previewOutput ) );
 
@@ -460,7 +460,7 @@ class PFAutoeditAPI extends ApiBase {
 				// show normal Edit page
 
 				// remove Preview and Diff standard buttons from editor page
-				Hooks::register( 'EditPageBeforeEditButtons', static function ( &$editor, &$buttons, &$tabindex ){
+				MediaWikiServices::getInstance()->getHookContainer()->register( 'EditPageBeforeEditButtons', static function ( &$editor, &$buttons, &$tabindex ){
 					foreach ( array_keys( $buttons ) as $key ) {
 						if ( $key !== 'save' ) {
 							unset( $buttons[$key] );
@@ -510,7 +510,7 @@ class PFAutoeditAPI extends ApiBase {
 				// Give extensions a chance to modify URL query on create
 				$sectionanchor = null;
 				$extraQuery = null;
-				Hooks::run( 'ArticleUpdateBeforeRedirect', [ $editor->getArticle(), &$sectionanchor, &$extraQuery ] );
+				MediaWikiServices::getInstance()->getHookContainer()->run( 'ArticleUpdateBeforeRedirect', [ $editor->getArticle(), &$sectionanchor, &$extraQuery ] );
 
 				// @phan-suppress-next-line PhanImpossibleCondition
 				if ( $extraQuery ) {
@@ -544,7 +544,7 @@ class PFAutoeditAPI extends ApiBase {
 				$sectionanchor = $resultDetails['sectionanchor'];
 
 				// Give extensions a chance to modify URL query on update
-				Hooks::run( 'ArticleUpdateBeforeRedirect', [ $editor->getArticle(), &$sectionanchor, &$extraQuery ] );
+				MediaWikiServices::getInstance()->getHookContainer()->run( 'ArticleUpdateBeforeRedirect', [ $editor->getArticle(), &$sectionanchor, &$extraQuery ] );
 
 				if ( $resultDetails['redirect'] ) {
 					// @phan-suppress-next-line PhanSuspiciousValueComparison
@@ -909,9 +909,9 @@ class PFAutoeditAPI extends ApiBase {
 		// Allow extensions to set/change the preload text, for new
 		// pages.
 		if ( !$pageExists ) {
-			Hooks::run( 'PageForms::EditFormPreloadText', [ &$preloadContent, $targetTitle, $formTitle ] );
+			MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::EditFormPreloadText', [ &$preloadContent, $targetTitle, $formTitle ] );
 		} else {
-			Hooks::run( 'PageForms::EditFormInitialText', [ &$preloadContent, $targetTitle, $formTitle ] );
+			MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::EditFormInitialText', [ &$preloadContent, $targetTitle, $formTitle ] );
 		}
 
 		// Flag to keep track of formHTML() runs.
@@ -1002,7 +1002,7 @@ class PFAutoeditAPI extends ApiBase {
 			}
 
 			// Lets other code process additional form-definition syntax
-			Hooks::run( 'PageForms::WritePageData', [ $this->mOptions['form'], Title::newFromText( $this->mOptions['target'] ), &$targetContent ] );
+			MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::WritePageData', [ $this->mOptions['form'], Title::newFromText( $this->mOptions['target'] ), &$targetContent ] );
 
 			$editor = $this->setupEditPage( $targetContent );
 

--- a/includes/PF_FormLinker.php
+++ b/includes/PF_FormLinker.php
@@ -58,7 +58,7 @@ class PFFormLinker {
 		$preloadContent = null;
 
 		// Allow outside code to set/change the preloaded text.
-		Hooks::run( 'PageForms::EditFormPreloadText', [ &$preloadContent, $title, $formTitle ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::EditFormPreloadText', [ &$preloadContent, $title, $formTitle ] );
 
 		[ $formText, $pageText, $formPageTitle, $generatedPageName ] =
 			$wgPageFormsFormPrinter->formHTML(

--- a/includes/PF_FormPrinter.php
+++ b/includes/PF_FormPrinter.php
@@ -1936,7 +1936,11 @@ END;
 			// This variable is called $mwWikiPage and not
 			// something simpler, to avoid confusion with the
 			// variable $wiki_page, which is of type PFWikiPage.
-			$mwWikiPage = WikiPage::factory( $this->mPageTitle );
+			if ( version_compare( MW_VERSION, '1.39', '>=' ) ) {
+				$mwWikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $this->mPageTitle );
+			} else {
+				$mwWikiPage = WikiPage::factory( $this->mPageTitle );
+			}
 			$form_text .= Html::hidden( 'wpEdittime', $mwWikiPage->getTimestamp() );
 			$form_text .= Html::hidden( 'editRevId', 0 );
 			$form_text .= Html::hidden( 'wpEditToken', $user->getEditToken() );

--- a/includes/PF_FormPrinter.php
+++ b/includes/PF_FormPrinter.php
@@ -112,7 +112,7 @@ class PFFormPrinter {
 		// All-purpose setup hook.
 		// Avoid PHP 7.1 warning from passing $this by reference.
 		$formPrinterRef = $this;
-		Hooks::run( 'PageForms::FormPrinterSetup', [ &$formPrinterRef ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::FormPrinterSetup', [ &$formPrinterRef ] );
 	}
 
 	public function setSemanticTypeHook( $type, $is_list, $class_name, $default_args ) {
@@ -924,7 +924,7 @@ END;
 				$permissionErrors = [ [ 'readonlytext', [ MediaWikiServices::getInstance()->getReadOnlyMode()->getReason() ] ] ];
 			}
 			$userCanEditPage = count( $permissionErrors ) == 0;
-			Hooks::run( 'PageForms::UserCanEditPage', [ $this->mPageTitle, &$userCanEditPage ] );
+			MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::UserCanEditPage', [ $this->mPageTitle, &$userCanEditPage ] );
 		}
 
 		// Start off with a loading spinner - this will be removed by
@@ -1350,10 +1350,10 @@ END;
 						// @TODO - should it be $cur_value for both cases? Or should the
 						// hook perhaps modify both variables?
 						if ( $form_submitted ) {
-							Hooks::run( 'PageForms::CreateFormField', [ &$form_field, &$cur_value_in_template, true ] );
+							MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::CreateFormField', [ &$form_field, &$cur_value_in_template, true ] );
 						} else {
 							$this->createFormFieldTranslateTag( $template, $tif, $form_field, $cur_value );
-							Hooks::run( 'PageForms::CreateFormField', [ &$form_field, &$cur_value, false ] );
+							MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::CreateFormField', [ &$form_field, &$cur_value, false ] );
 						}
 						// if this is not part of a 'multiple' template, increment the
 						// global tab index (used for correct tabbing)
@@ -1897,7 +1897,7 @@ END;
 
 		$page_text = '';
 
-		Hooks::run( 'PageForms::BeforeFreeTextSubst',
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::BeforeFreeTextSubst',
 			[ &$free_text, $existing_page_content, &$page_text ] );
 
 		// Now that we have the free text, we can create the full page
@@ -1950,7 +1950,7 @@ END;
 
 		$form_text .= "\t</form>\n";
 		$parser->replaceLinkHolders( $form_text );
-		Hooks::run( 'PageForms::RenderingEnd', [ &$form_text ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::RenderingEnd', [ &$form_text ] );
 
 		// Send the autocomplete values to the browser, along with the
 		// mappings of which values should apply to which fields.

--- a/includes/PF_Hooks.php
+++ b/includes/PF_Hooks.php
@@ -45,22 +45,27 @@ class PFHooks {
 	}
 
 	public static function initialize() {
-		global $wgHooks;
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 
 		$GLOBALS['wgPageFormsScriptPath'] = $GLOBALS['wgExtensionAssetsPath'] . '/PageForms';
 
 		if ( class_exists( 'MediaWiki\HookContainer\HookContainer' ) ) {
 			// MW 1.35+
-			$wgHooks['PageSaveComplete'][] = 'PFHooks::setPostEditCookie';
-			$wgHooks['MultiContentSave'][] = 'PFFormUtils::purgeCache2';
+			$hookContainer->register( 'PageSaveComplete',
+				'PFHooks::setPostEditCookie' );
+			$hookContainer->register( 'MultiContentSave',
+				'PFFormUtils::purgeCache2' );
 		} else {
-			$wgHooks['PageContentSaveComplete'][] = 'PFHooks::setPostEditCookieOld';
-			$wgHooks['PageContentSave'][] = 'PFFormUtils::purgeCache';
+			$hookContainer->register( 'PageContentSaveComplete',
+				'PFHooks::setPostEditCookieOld' );
+			$hookContainer->register( 'PageContentSave',
+				'PFFormUtils::purgeCache' );
 		}
 		// Admin Links hook needs to be called in a delayed way so that it
 		// will always be called after SMW's Admin Links addition; as of
 		// SMW 1.9, SMW delays calling all its hook functions.
-		$wgHooks['AdminLinks'][] = 'PFHooks::addToAdminLinks';
+		$hookContainer->register( 'AdminLinks',
+				'PFHooks::addToAdminLinks' );
 
 		// This global variable is needed so that other
 		// extensions can hook into it to add their own

--- a/includes/PF_Template.php
+++ b/includes/PF_Template.php
@@ -456,7 +456,7 @@ class PFTemplate {
 	public function createText() {
 		// Avoid PHP 7.1 warning from passing $this by reference
 		$template = $this;
-		Hooks::run( 'PageForms::CreateTemplateText', [ &$template ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::CreateTemplateText', [ &$template ] );
 		$text = <<<END
 <noinclude>
 {{#template_params:
@@ -703,7 +703,7 @@ END;
 	public function createTextForField( $field ) {
 		$text = '';
 		$fieldStart = $this->mFieldStart;
-		Hooks::run( 'PageForms::TemplateFieldStart', [ $field, &$fieldStart ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::TemplateFieldStart', [ $field, &$fieldStart ] );
 		if ( $fieldStart != '' ) {
 			$text .= "$fieldStart ";
 		}
@@ -712,7 +712,7 @@ END;
 		$text .= $field->createText( $cargoInUse );
 
 		$fieldEnd = $this->mFieldEnd;
-		Hooks::run( 'PageForms::TemplateFieldEnd', [ $field, &$fieldEnd ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::TemplateFieldEnd', [ $field, &$fieldEnd ] );
 		if ( $fieldEnd != '' ) {
 			$text .= " $fieldEnd";
 		}

--- a/includes/PF_Utils.php
+++ b/includes/PF_Utils.php
@@ -248,7 +248,7 @@ END;
 
 END;
 		// @TODO - remove this hook? It seems useless.
-		Hooks::run( 'PageForms::PrintRedirectForm', [ $is_save, !$is_save, false, &$text ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::PrintRedirectForm', [ $is_save, !$is_save, false, &$text ] );
 		return $text;
 	}
 
@@ -300,7 +300,7 @@ END;
 		$output->addModules( $mainModules );
 
 		$otherModules = [];
-		Hooks::run( 'PageForms::AddRLModules', [ &$otherModules ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::AddRLModules', [ &$otherModules ] );
 		// @phan-suppress-next-line PhanEmptyForeach
 		foreach ( $otherModules as $rlModule ) {
 			$output->addModules( $rlModule );

--- a/includes/PF_ValuesUtils.php
+++ b/includes/PF_ValuesUtils.php
@@ -61,7 +61,11 @@ class PFValuesUtils {
 	 */
 	public static function getCategoriesForPage( $title ) {
 		$categories = [];
-		$db = wfGetDB( DB_REPLICA );
+		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+			$db = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
+		} else {
+			$db = wfGetDB( DB_REPLICA );
+		}
 		$titlekey = $title->getArticleID();
 		if ( $titlekey == 0 ) {
 			// Something's wrong - exit
@@ -87,7 +91,11 @@ class PFValuesUtils {
 	 */
 	public static function getAllCategories() {
 		$categories = [];
-		$db = wfGetDB( DB_REPLICA );
+		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+			$db = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
+		} else {
+			$db = wfGetDB( DB_REPLICA );
+		}
 		$res = $db->select(
 			'category',
 			'cat_title',
@@ -194,7 +202,11 @@ class PFValuesUtils {
 		}
 		global $wgPageFormsMaxAutocompleteValues, $wgPageFormsUseDisplayTitle;
 
-		$db = wfGetDB( DB_REPLICA );
+		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+			$db = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
+		} else {
+			$db = wfGetDB( DB_REPLICA );
+		}
 		$top_category = str_replace( ' ', '_', $top_category );
 		$categories = [ $top_category ];
 		$checkcategories = [ $top_category ];
@@ -489,7 +501,11 @@ class PFValuesUtils {
 			$namespaceConditions[] = "page_namespace = $matchingNamespaceCode";
 		}
 
-		$db = wfGetDB( DB_REPLICA );
+		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+			$db = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
+		} else {
+			$db = wfGetDB( DB_REPLICA );
+		}
 		$conditions = [];
 		$conditions[] = implode( ' OR ', $namespaceConditions );
 		$tables = [ 'page' ];
@@ -775,7 +791,11 @@ class PFValuesUtils {
 	public static function getSQLConditionForAutocompleteInColumn( $column, $substring, $replaceSpaces = true ) {
 		global $wgPageFormsAutocompleteOnAllChars;
 
-		$db = wfGetDB( DB_REPLICA );
+		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+			$db = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
+		} else {
+			$db = wfGetDB( DB_REPLICA );
+		}
 
 		// CONVERT() is also supported in PostgreSQL, but it doesn't
 		// seem to work the same way.

--- a/includes/forminputs/PF_RadioButtonInput.php
+++ b/includes/forminputs/PF_RadioButtonInput.php
@@ -74,13 +74,12 @@ class PFRadioButtonInput extends PFEnumInput {
 			if ( $value === '' ) {
 				// blank/"None" value
 				$label = wfMessage( 'pf_formedit_none' )->text();
-			} elseif  (
-				array_key_exists( 'value_labels', $other_args ) && 
-     			is_string( $other_args['value_labels'] ) 
-			) {
+			} elseif (
+				array_key_exists( 'value_labels', $other_args ) &&
+				is_string( $other_args['value_labels'] ) ) {
 				$other_args['value_labels'] = json_decode( $other_args['value_labels'], true );
 				$label = htmlspecialchars( $other_args['value_labels'][$value] );
-			} elseif  (
+			} elseif (
 				array_key_exists( 'value_labels', $other_args ) &&
 				is_array( $other_args['value_labels'] ) &&
 				array_key_exists( $value, $other_args['value_labels'] )

--- a/includes/forminputs/PF_RadioButtonInput.php
+++ b/includes/forminputs/PF_RadioButtonInput.php
@@ -16,7 +16,7 @@ class PFRadioButtonInput extends PFEnumInput {
 	public static function getHTML( $cur_value, $input_name, $is_mandatory, $is_disabled, array $other_args ) {
 		global $wgPageFormsTabIndex, $wgPageFormsFieldNum, $wgPageFormsShowOnSelect;
 
-		if ( array_key_exists( 'possible_values', $other_args ) ) {
+		if ( array_key_exists( 'possible_values', $other_args ) && ( count( $other_args['possible_values'] ) > 0 ) ) {
 			$possible_values = $other_args['possible_values'];
 		} elseif (
 			array_key_exists( 'property_type', $other_args ) &&
@@ -74,7 +74,13 @@ class PFRadioButtonInput extends PFEnumInput {
 			if ( $value === '' ) {
 				// blank/"None" value
 				$label = wfMessage( 'pf_formedit_none' )->text();
-			} elseif (
+			} elseif  (
+				array_key_exists( 'value_labels', $other_args ) && 
+     			is_string( $other_args['value_labels'] ) 
+			) {
+				$other_args['value_labels'] = json_decode( $other_args['value_labels'], true );
+				$label = htmlspecialchars( $other_args['value_labels'][$value] );
+			} elseif  (
 				array_key_exists( 'value_labels', $other_args ) &&
 				is_array( $other_args['value_labels'] ) &&
 				array_key_exists( $value, $other_args['value_labels'] )

--- a/includes/parserfunctions/PF_AutoEdit.php
+++ b/includes/parserfunctions/PF_AutoEdit.php
@@ -101,7 +101,11 @@ class PFAutoEdit {
 							$errorMsg = wfMessage( 'pf-autoedit-invalidnamespace', $targetTitle->getNsText() )->parse();
 							return Html::element( 'div', [ 'class' => 'error' ], $errorMsg );
 						}
-						$targetWikiPage = WikiPage::factory( $targetTitle );
+						if ( version_compare( MW_VERSION, '1.39', '>=' ) ) {
+							$targetWikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $targetTitle );
+						} else {
+							$targetWikiPage = WikiPage::factory( $targetTitle );
+						}
 						$targetWikiPage->clear();
 						$editTime = $targetWikiPage->getTimestamp();
 						$latestRevId = $targetWikiPage->getLatest();

--- a/includes/parserfunctions/PF_AutoEditRating.php
+++ b/includes/parserfunctions/PF_AutoEditRating.php
@@ -59,7 +59,11 @@ class PFAutoEditRating {
 							$errorMsg = wfMessage( 'pf-autoedit-invalidnamespace', $targetTitle->getNsText() )->parse();
 							return Html::element( 'div', [ 'class' => 'error' ], $errorMsg );
 						}
-						$targetWikiPage = WikiPage::factory( $targetTitle );
+						if ( version_compare( MW_VERSION, '1.39', '>=' ) ) {
+							$targetWikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $targetTitle );
+						} else {
+							$targetWikiPage = WikiPage::factory( $targetTitle );
+						}
 						$targetWikiPage->clear();
 						$editTime = $targetWikiPage->getTimestamp();
 						$latestRevId = $targetWikiPage->getLatest();

--- a/includes/parserfunctions/PF_FormInputParserFunction.php
+++ b/includes/parserfunctions/PF_FormInputParserFunction.php
@@ -33,6 +33,8 @@
  * |query string=namespace=User&preload=UserStub}}
  */
 
+use MediaWiki\MediaWikiServices;
+
 class PFFormInputParserFunction {
 	/**
 	 * static variable to guarantee that JavaScript for autocompletion
@@ -209,7 +211,7 @@ class PFFormInputParserFunction {
 		$formInputAttrs['data-button-label'] = ( $inButtonStr != '' ) ? $inButtonStr : wfMessage( 'pf_formstart_createoredit' )->escaped();
 		$formContents .= Html::element( 'div', $formInputAttrs, null );
 
-		Hooks::run( 'PageForms::FormInputEnd', [ $params, &$formContents ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::FormInputEnd', [ $params, &$formContents ] );
 
 		$str = "\t" . Html::rawElement( 'form', [
 				'name' => 'createbox',

--- a/specials/PF_FormEdit.php
+++ b/specials/PF_FormEdit.php
@@ -8,6 +8,8 @@
  * @ingroup PF
  */
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * @ingroup PFSpecialPages
  */
@@ -200,7 +202,7 @@ class PFFormEdit extends UnlistedSpecialPage {
 
 		$text .= '<form name="createbox" id="pfForm" method="post" class="createbox">';
 		$pre_form_html = '';
-		Hooks::run( 'PageForms::HTMLBeforeForm', [ &$targetTitle, &$pre_form_html ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'PageForms::HTMLBeforeForm', [ &$targetTitle, &$pre_form_html ] );
 		$text .= $pre_form_html;
 
 		$out->addHTML( $text );

--- a/specials/PF_UploadForm.php
+++ b/specials/PF_UploadForm.php
@@ -7,6 +7,8 @@
  * @ingroup PF
  */
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * @ingroup PFSpecialPages
  */
@@ -174,7 +176,7 @@ class PFUploadForm extends HTMLForm {
 				'checked' => $selectedSourceType == 'url',
 			];
 		}
-		Hooks::run( 'UploadFormSourceDescriptors', [ &$descriptor, &$radio, $selectedSourceType ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'UploadFormSourceDescriptors', [ &$descriptor, &$radio, $selectedSourceType ] );
 
 		$descriptor['Extensions'] = [
 			'type' => 'info',

--- a/specials/PF_UploadWindow.php
+++ b/specials/PF_UploadWindow.php
@@ -236,7 +236,7 @@ class PFUploadWindow extends UnlistedSpecialPage {
 			# Backwards compatibility hook
 			// Avoid PHP 7.1 warning from passing $this by reference
 			$page = $this;
-			if ( !Hooks::run( 'UploadForm:initial', [ &$page ] ) ) {
+			if ( !MediaWikiServices::getInstance()->getHookContainer()->run( 'UploadForm:initial', [ &$page ] ) ) {
 				wfDebug( "Hook 'UploadForm:initial' broke output of the upload form" );
 				return;
 			}
@@ -439,7 +439,7 @@ class PFUploadWindow extends UnlistedSpecialPage {
 
 		// Avoid PHP 7.1 warning from passing $this by reference
 		$page = $this;
-		if ( !Hooks::run( 'UploadForm:BeforeProcessing', [ &$page ] ) ) {
+		if ( !MediaWikiServices::getInstance()->getHookContainer()->run( 'UploadForm:BeforeProcessing', [ &$page ] ) ) {
 			wfDebug( "Hook 'UploadForm:BeforeProcessing' broke processing the file.\n" );
 			// This code path is deprecated. If you want to break upload processing
 			// do so by hooking into the appropriate hooks in UploadBase::verifyUpload
@@ -549,7 +549,7 @@ END;
 
 		// Avoid PHP 7.1 warning from passing $this by reference
 		$page = $this;
-		Hooks::run( 'SpecialUploadComplete', [ &$page ] );
+		MediaWikiServices::getInstance()->getHookContainer()->run( 'SpecialUploadComplete', [ &$page ] );
 	}
 
 	/**

--- a/tests/phpunit/integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -24,6 +24,8 @@ $wgExtraNamespaces[TEST_NAMESPACE] = "Test_Namespace";
 /**
  * @group PF
  * @group SMWExtension
+ * @group Database
+ *
  */
 class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
 

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-checkbox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-checkbox.json
@@ -10,6 +10,11 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Checkbox without other parameters",
 			"contents": "{{{field|Checkbox|input type=checkbox}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Checkbox with parameter label",
+			"contents": "{{{field|Checkbox|input type=checkbox|label=Test1}}}"
 		}
 	],
 	"tests": [
@@ -28,6 +33,27 @@
                     "name='standard input[Checkbox][value]'",
                     "class='oo-ui-inputWidget-input' />",
 					"standard input[Checkbox][is_checkbox]"
+                ],
+			"not-contain": [
+					"<label for=\"input_1\""
+				]
+		    }
+	    },
+		{
+			"type": "special",
+			"about": "Checkbox with parameter label",
+			"special-page": {
+			"page": "FormEdit",
+			"query-parameters": "Checkbox with parameter label/01",
+			"request-parameters": {}
+			},
+			"assert-output": {
+            "to-contain": [
+                    "<label for=\"input_1\"",
+					"<input type=\"hidden\" value=\"true\" name=\"standard input[Checkbox][is_checkbox]\"",
+					"<input type='checkbox'",
+					"name='standard input[Checkbox][value]'",
+					"Test1</label>"
                 ]
 		    }
 	    }

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-combobox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-combobox.json
@@ -10,6 +10,16 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Combobox without values",
 			"contents": "{{{field|Combobox|input type=combobox}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Combobox with parameter placeholder",
+			"contents": "{{{field|Combobox|input type=combobox|placeholder=This is TEST}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Combobox with parameter existing values only",
+			"contents": "{{{field|Combobox|input type=combobox|existing values only}}}"
 		}
 	],
 	"tests": [
@@ -27,6 +37,42 @@
 					"<select id=\"input_1\" name=\"standard input[Combobox]\" class=\"pfComboBox\" tabindex=\"1\" autocompletesettings=\"\" data-size=\"210\" style=\"width:210px\">",
 					"<option value=\"\"></option>",
                     "<option selected=\"\"></option>"
+				],
+				"not-contain": [
+					"placeholder=\"This is TEST\""
+				]
+		    }
+		},
+		{
+			"type": "special",
+			"about": "Combobox with parameter placeholder",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Combobox with parameter placeholder/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"comboboxSpan\" data-input-type=\"combobox\">",
+					"<select id=\"input_1\" name=\"standard input[Combobox]\" class=\"pfComboBox\" tabindex=\"1\" autocompletesettings=\"\" data-size=\"210\" style=\"width:210px\" placeholder=\"This is TEST\""
+				],
+				"not-contain": [
+					"existingvaluesonly=\"true\""
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Combobox with parameter existing values only",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Combobox with parameter existing values only/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"comboboxSpan\" data-input-type=\"combobox\">",
+					"<select id=\"input_1\" name=\"standard input[Combobox]\" class=\"pfComboBox\" tabindex=\"1\" autocompletesettings=\"\" data-size=\"210\" style=\"width:210px\" existingvaluesonly=\"true\""
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-datepicker.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-datepicker.json
@@ -8,17 +8,27 @@
 		},
 		{
 			"namespace": "PF_NS_FORM",
-			"page": "Datepicker with values",
+			"page": "Datepicker without values",
 			"contents": "{{{field|Datepicker|input type=datepicker}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Datepicker with first date parameter",
+			"contents": "{{{field|Datepicker|input type=datepicker|first date=2025-01-20}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Datepicker with date format parameter",
+			"contents": "{{{field|Datepicker|input type=datepicker|date format=DD-MM-YYYY}}}"
 		}
 	],
 	"tests": [
 		{
 			"type": "special",
-			"about": "Datepicker with values",
+			"about": "Datepicker without values",
 			"special-page": {
 				"page": "FormEdit",
-				"query-parameters": "Datepicker with values/01",
+				"query-parameters": "Datepicker without values/01",
 				"request-parameters": {}
 			},
 			"assert-output": {
@@ -26,6 +36,51 @@
 					"<div class=\"pfPickerWrapper\">",
 					"pfDatePicker",
 					"standard input[Datepicker]",
+					"placeholder='YYYY-MM-DD'"
+				],
+				"not-contain": [
+					"\"displayFormat\":\"DD-MM-YYYY\"",
+					"min='2025-01-21'"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Datepicker with first date parameter",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Datepicker with first date parameter/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfPickerWrapper\">",
+					"pfDatePicker",
+					"standard input[Datepicker]",
+					"placeholder='YYYY-MM-DD'",
+					"min='2025-01-21'"
+				],
+				"not-contain": [
+					"\"displayFormat\":\"DD-MM-YYYY\""
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Datepicker with date format parameter",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Datepicker with date format parameter/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfPickerWrapper\">",
+					"pfDatePicker",
+					"standard input[Datepicker]",
+					"\"displayFormat\":\"DD-MM-YYYY\""
+				],
+				"not-contain": [
 					"placeholder='YYYY-MM-DD'"
 				]
 			}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-datetime.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-datetime.json
@@ -10,6 +10,11 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Datetime without other parameters",
 			"contents": "{{{field|Datetime|input type=datetime}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Datetime with parameter include timezone",
+			"contents": "{{{field|Datetime|input type=datetime|include timezone}}}"
 		}
 	],
 	"tests": [
@@ -36,6 +41,39 @@
                     "standard input[Datetime][minute]",
                     "secondsInput",
                     "standard input[Datetime][second]"
+				],
+				"not-contain": [
+					"<input tabindex=\"5\" name=\"standard input[Datetime][timezone]\" type=\"text\" value=\"\" size=\"3\""
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Datetime with parameter include timezone",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Datetime with parameter include timezone/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"dateTimeInput\">",
+                    "dayInput",
+                    "standard input[Datetime][day]",
+                    "monthInput",
+                    "standard input[Datetime][month]",
+                    "yearInput",
+                    "standard input[Datetime][year]",
+                    "hoursInput",
+                    "standard input[Datetime][hour]",
+                    "minutesInput",
+                    "standard input[Datetime][minute]",
+                    "secondsInput",
+                    "standard input[Datetime][second]",
+					"<select tabindex=\"4\" name=\"standard input[Datetime][ampm24h]\" class=\"ampmInput\"",
+					"<option value=\"AM\">AM</option>",
+					"<option value=\"PM\">PM</option>",
+					"<input tabindex=\"5\" name=\"standard input[Datetime][timezone]\" type=\"text\" value=\"\" size=\"3\""
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-googlemaps.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-googlemaps.json
@@ -25,7 +25,7 @@
 				"to-contain": [
                     "<div class=\"pfGoogleMapsInput\">",
                     "placeholder='Enter address here'",
-                    "<input tabindex=\"3\" class=\"pfCoordsInput\" name=\"standard input[Googlemaps]\" size=\"40\"/>",
+                    "<input tabindex=\"3\" class=\"pfCoordsInput\" name=\"standard input[Googlemaps]\" size=\"40\"",
                     "<span class='oo-ui-labelElement-label'>Calculate coordinates using address</span>",
 					"<div class=\"pfMapCanvas\" id=\"pfMapCanvas1\" style=\"height: 500px; width: 500px;\">"
 				]

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-leaflet.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-leaflet.json
@@ -25,7 +25,7 @@
 				"to-contain": [
                     "<div class=\"pfLeafletInput\">",
                     "placeholder='Enter address here'",
-                    "<input tabindex=\"3\" class=\"pfCoordsInput\" name=\"standard input[Leaflet]\" size=\"40\"/>",
+                    "<input tabindex=\"3\" class=\"pfCoordsInput\" name=\"standard input[Leaflet]\" size=\"40\"",
                     "<span class='oo-ui-labelElement-label'>Calculate coordinates using address</span>",
 					"<div class=\"pfMapCanvas\" id=\"pfMapCanvas1\" style=\"height: 500px; width: 500px;\">"
 				]

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-listbox.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-listbox.json
@@ -10,6 +10,11 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Listbox without other parameters",
 			"contents": "{{{field|Listbox|input type=listbox}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Listbox with parameter size",
+			"contents": "{{{field|Listbox|input type=listbox|size=25}}}"
 		}
 	],
 	"tests": [
@@ -24,6 +29,23 @@
 			"assert-output": {
 				"to-contain": [
 					"<select id=\"input_1\" tabindex=\"1\" name=\"standard input[Listbox][]\" class=\"createboxInput pfShowIfSelected\" multiple=\"\"></select>"
+				],
+				"not-contain": [
+					"size=\"25\""
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Listbox with parameter size",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Listbox with parameter size/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<select id=\"input_1\" tabindex=\"1\" name=\"standard input[Listbox][]\" class=\"createboxInput pfShowIfSelected\" multiple=\"\" size=\"25\"></select>"
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-openlayers.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-openlayers.json
@@ -28,7 +28,7 @@
 					"placeholder='Enter address here'",
 					"pfLookUpAddress",
 					"<span class='oo-ui-labelElement-label'>Calculate coordinates using address</span>",
-					"<input tabindex=\"3\" class=\"pfCoordsInput\" name=\"standard input[Openlayers]\" size=\"40\"/>"
+					"<input tabindex=\"3\" class=\"pfCoordsInput\" name=\"standard input[Openlayers]\" size=\"40\""
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-radiobutton.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-radiobutton.json
@@ -45,7 +45,7 @@
 				"to-contain": [
 					"<label class=\"radioButtonItem\">",
 					"<input id=\"input_2\" tabindex=\"2\" data-original-value=\"0\" checked=\"\" type=\"radio\" value=\"\" name=\"standard input[Radiobutton]\"",
-					"&nbsp;None"		
+					"&nbsp;None"	
 				]
 			}
 		},
@@ -64,7 +64,7 @@
 					"&nbsp;Radio A",
 					"<label class=\"radioButtonItem\">",
 					"<input id=\"input_4\" tabindex=\"4\" data-original-value=\"2\" type=\"radio\" value=\"Radio B\" name=\"standard input[Radiobutton]\"",
-					"&nbsp;Radio B"	
+					"&nbsp;Radio B"
 				]
 			}
 		},

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-radiobutton.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-radiobutton.json
@@ -15,6 +15,21 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Radiobutton with values",
 			"contents": "{{{field|Radiobutton|input type=radiobutton|values=Radio A,Radio B}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Radiobutton with possible values",
+			"contents": "{{{field|Radiobutton|input type=radiobutton|values=Option 1,Option 2,Option 3}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Radiobutton with custom value labels",
+			"contents": "{{{field|Radiobutton|input type=radiobutton|values=eins,zwei,drei|value_labels={\"eins\":\"One\",\"zwei\":\"Two\",\"drei\":\"Three\"}}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Radiobutton with boolean property",
+			"contents": "{{{field|Radiobutton|input type=radiobutton|property_type=_boo}}}"
 		}
 	],
     "tests": [
@@ -50,6 +65,63 @@
 					"<label class=\"radioButtonItem\">",
 					"<input id=\"input_4\" tabindex=\"4\" data-original-value=\"2\" type=\"radio\" value=\"Radio B\" name=\"standard input[Radiobutton]\"",
 					"&nbsp;Radio B"	
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Radiobutton with possible values",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Radiobutton with possible values/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<label class=\"radioButtonItem\">",
+					"<input id=\"input_3\" tabindex=\"3\" data-original-value=\"1\" type=\"radio\" value=\"Option 1\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Option 1",
+					"<input id=\"input_4\" tabindex=\"4\" data-original-value=\"2\" type=\"radio\" value=\"Option 2\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Option 2",
+					"<input id=\"input_5\" tabindex=\"5\" data-original-value=\"3\" type=\"radio\" value=\"Option 3\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Option 3"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Radiobutton with custom value labels",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Radiobutton with custom value labels/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<label class=\"radioButtonItem\">",
+					"<input id=\"input_3\" tabindex=\"3\" data-original-value=\"1\" type=\"radio\" value=\"eins\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;One",
+					"<input id=\"input_4\" tabindex=\"4\" data-original-value=\"2\" type=\"radio\" value=\"zwei\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Two",
+					"<input id=\"input_5\" tabindex=\"5\" data-original-value=\"3\" type=\"radio\" value=\"drei\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Three"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Radiobutton with boolean property",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Radiobutton with boolean property/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<input id=\"input_3\" tabindex=\"3\" data-original-value=\"1\" type=\"radio\" value=\"Yes\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Yes",
+					"<input id=\"input_4\" tabindex=\"4\" data-original-value=\"2\" type=\"radio\" value=\"No\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;No"
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-radiobutton.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-radiobutton.json
@@ -28,7 +28,10 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<label class=\"radioButtonItem\"><input id=\"input_2\" tabindex=\"2\" data-original-value=\"0\" checked=\"\" type=\"radio\" value=\"\" name=\"standard input[Radiobutton]\"/>&nbsp;None</label>"				]
+					"<label class=\"radioButtonItem\">",
+					"<input id=\"input_2\" tabindex=\"2\" data-original-value=\"0\" checked=\"\" type=\"radio\" value=\"\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;None"		
+				]
 			}
 		},
 		{
@@ -41,8 +44,12 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<label class=\"radioButtonItem\"><input id=\"input_3\" tabindex=\"3\" data-original-value=\"1\" type=\"radio\" value=\"Radio A\" name=\"standard input[Radiobutton]\"/>&nbsp;Radio A</label>",
-					"<label class=\"radioButtonItem\"><input id=\"input_4\" tabindex=\"4\" data-original-value=\"2\" type=\"radio\" value=\"Radio B\" name=\"standard input[Radiobutton]\"/>&nbsp;Radio B</label>"
+					"<label class=\"radioButtonItem\">",
+					"<input id=\"input_3\" tabindex=\"3\" data-original-value=\"1\" type=\"radio\" value=\"Radio A\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Radio A",
+					"<label class=\"radioButtonItem\">",
+					"<input id=\"input_4\" tabindex=\"4\" data-original-value=\"2\" type=\"radio\" value=\"Radio B\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Radio B"	
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-radiobutton.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-radiobutton.json
@@ -30,6 +30,16 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Radiobutton with boolean property",
 			"contents": "{{{field|Radiobutton|input type=radiobutton|property_type=_boo}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Radiobutton with values and mandatory param",
+			"contents": "{{{field|Radiobutton|input type=radiobutton|values=Button1|mandatory}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Radiobutton with values and default param",
+			"contents": "{{{field|Radiobutton|input type=radiobutton|values=Button1,Button2|default=Button2}}}"
 		}
 	],
     "tests": [
@@ -46,6 +56,9 @@
 					"<label class=\"radioButtonItem\">",
 					"<input id=\"input_2\" tabindex=\"2\" data-original-value=\"0\" checked=\"\" type=\"radio\" value=\"\" name=\"standard input[Radiobutton]\"",
 					"&nbsp;None"
+				],
+				"not-contain": [
+					"\"radioButtonSpan mandatoryFieldSpan\""
 				]
 			}
 		},
@@ -65,6 +78,9 @@
 					"<label class=\"radioButtonItem\">",
 					"<input id=\"input_4\" tabindex=\"4\" data-original-value=\"2\" type=\"radio\" value=\"Radio B\" name=\"standard input[Radiobutton]\"",
 					"&nbsp;Radio B"
+				],
+				"not-contain": [
+					"\"radioButtonSpan mandatoryFieldSpan\""
 				]
 			}
 		},
@@ -85,6 +101,9 @@
 					"&nbsp;Option 2",
 					"<input id=\"input_5\" tabindex=\"5\" data-original-value=\"3\" type=\"radio\" value=\"Option 3\" name=\"standard input[Radiobutton]\"",
 					"&nbsp;Option 3"
+				],
+				"not-contain": [
+					"\"radioButtonSpan mandatoryFieldSpan\""
 				]
 			}
 		},
@@ -105,6 +124,9 @@
 					"&nbsp;Two",
 					"<input id=\"input_5\" tabindex=\"5\" data-original-value=\"3\" type=\"radio\" value=\"drei\" name=\"standard input[Radiobutton]\"",
 					"&nbsp;Three"
+				],
+				"not-contain": [
+					"\"radioButtonSpan mandatoryFieldSpan\""
 				]
 			}
 		},
@@ -122,6 +144,42 @@
 					"&nbsp;Yes",
 					"<input id=\"input_4\" tabindex=\"4\" data-original-value=\"2\" type=\"radio\" value=\"No\" name=\"standard input[Radiobutton]\"",
 					"&nbsp;No"
+				],
+				"not-contain": [
+					"\"radioButtonSpan mandatoryFieldSpan\""
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Radiobutton with values and mandatory param",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Radiobutton with values and mandatory param/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span id=\"span_2\" class=\"radioButtonSpan mandatoryFieldSpan\"",
+					"<input id=\"input_2\" tabindex=\"2\" data-original-value=\"0\" type=\"radio\" value=\"Button1\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Button1"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Radiobutton with values and default param",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Radiobutton with values and default param/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<input id=\"input_3\" tabindex=\"3\" data-original-value=\"1\" type=\"radio\" value=\"Button1\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Button1",
+					"<input id=\"input_4\" tabindex=\"4\" data-original-value=\"2\" checked=\"\" type=\"radio\" value=\"Button2\" name=\"standard input[Radiobutton]\"",
+					"&nbsp;Button2"
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-radiobutton.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-radiobutton.json
@@ -45,7 +45,7 @@
 				"to-contain": [
 					"<label class=\"radioButtonItem\">",
 					"<input id=\"input_2\" tabindex=\"2\" data-original-value=\"0\" checked=\"\" type=\"radio\" value=\"\" name=\"standard input[Radiobutton]\"",
-					"&nbsp;None"	
+					"&nbsp;None"
 				]
 			}
 		},

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-rating.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-rating.json
@@ -10,6 +10,21 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Rating without other parameters",
 			"contents": "{{{field|Rating|input type=rating}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Rating with num stars parameter",
+			"contents": "{{{field|Rating|input type=rating|num stars=10}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Rating with num stars and star width parameters",
+			"contents": "{{{field|Rating|input type=rating|num stars=14|star width=40px}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Rating with allow half stars parameter",
+			"contents": "{{{field|Rating|input type=rating|allow half stars}}}"
 		}
 	],
 	"tests": [
@@ -24,6 +39,48 @@
 			"assert-output": {
 				"to-contain": [
 					"<div class=\"pfRating\" data-starwidth=\"24px\" data-numstars=\"5\">"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Rating with num stars parameter",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Rating with num stars parameter/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfRating\" data-starwidth=\"24px\" data-numstars=\"10\">"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Rating with num stars and star width parameters",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Rating with num stars and star width parameters/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfRating\" data-starwidth=\"40px\" data-numstars=\"14\">"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Rating with allow half stars parameter",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Rating with allow half stars parameter/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfRating\" data-starwidth=\"24px\" data-numstars=\"5\" data-allows-half=\"1\">"
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-text.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-text.json
@@ -10,6 +10,16 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Text input without other parameters",
 			"contents": "{{{field|Text|input type=text}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Text input with maxlength parameter",
+			"contents": "{{{field|Text|input type=text|maxlength=120}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Text input with placeholder parameter",
+			"contents": "{{{field|Text|input type=text|placeholder=This is TEXT placeholder}}}"
 		}
 	],
 	"tests": [
@@ -24,6 +34,38 @@
 			"assert-output": {
 				"to-contain": [
 					"<input id=\"input_1\" tabindex=\"1\" class=\"createboxInput\" size=\"35\" name=\"standard input[Text]\""
+				],
+				"not-contain": [
+					"maxlength=\"120\"",
+					"placeholder=\"This is TEXT placeholder\""
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Text input with maxlength parameter",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Text input with maxlength parameter/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<input id=\"input_1\" tabindex=\"1\" class=\"createboxInput\" size=\"35\" maxlength=\"120\" name=\"standard input[Text]\""
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Text input with placeholder parameter",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Text input with placeholder parameter/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<input id=\"input_1\" tabindex=\"1\" class=\"createboxInput\" size=\"35\" placeholder=\"This is TEXT placeholder\" name=\"standard input[Text]\""
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-text.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-text.json
@@ -23,7 +23,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<input id=\"input_1\" tabindex=\"1\" class=\"createboxInput\" size=\"35\" name=\"standard input[Text]\"/>"
+					"<input id=\"input_1\" tabindex=\"1\" class=\"createboxInput\" size=\"35\" name=\"standard input[Text]\""
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-timepicker.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-timepicker.json
@@ -23,7 +23,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<input id=\"input_1\" tabindex=\"1\" class=\"createboxInput\" size=\"35\" name=\"standard input[Timepicker]\"/>"
+					"<input id=\"input_1\" tabindex=\"1\" class=\"createboxInput\" size=\"35\" name=\"standard input[Timepicker]\""
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-tokens.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-tokens.json
@@ -10,6 +10,16 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Tokens without other parameters",
 			"contents": "{{{field|Tokens|input type=tokens}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Tokens with parameter placeholder",
+			"contents": "{{{field|Tokens|input type=tokens|placeholder=This is tokens TEST}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Tokens with parameter existing values only",
+			"contents": "{{{field|Tokens|input type=tokens|existing values only}}}"
 		}
 	],
 	"tests": [
@@ -24,6 +34,34 @@
 			"assert-output": {
 				"to-contain": [
 					"<select id=\"input_1\" name=\"standard input[Tokens][]\" class=\"pfTokens createboxInput\" style=\"width:450px\" multiple=\"\" size=\"1\" data-size=\"450px\" tabindex=\"1\" autocompletesettings=\",list,,\"></select>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Tokens with parameter placeholder",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Tokens with parameter placeholder/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<select id=\"input_1\" name=\"standard input[Tokens][]\" class=\"pfTokens createboxInput\" style=\"width:450px\" multiple=\"\" size=\"1\" data-size=\"450px\" tabindex=\"1\" autocompletesettings=\",list,,\" placeholder=\"This is tokens TEST\"></select>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Tokens with parameter existing values only",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Tokens with parameter existing values only/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<select id=\"input_1\" name=\"standard input[Tokens][]\" class=\"pfTokens createboxInput\" style=\"width:450px\" multiple=\"\" size=\"1\" data-size=\"450px\" tabindex=\"1\" autocompletesettings=\",list,,\" existingvaluesonly=\"true\"></select>"
 				]
 			}
 		}

--- a/tests/phpunit/integration/JSONScript/TestCases/forminput-tree.json
+++ b/tests/phpunit/integration/JSONScript/TestCases/forminput-tree.json
@@ -10,6 +10,16 @@
 			"namespace": "PF_NS_FORM",
 			"page": "Tree with structure params",
 			"contents": "{{{field|Tree|input type=tree|structure=*Test**Test1**Test2}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Tree with height and width params",
+			"contents": "{{{field|Tree|input type=tree|structure=*Test**Test1**Test2|width=200|height=300}}}"
+		},
+		{
+			"namespace": "PF_NS_FORM",
+			"page": "Tree with delimiter param",
+			"contents": "{{{field|Tree|input type=tree|structure=*Test**Test1**Test2|delimiter=:}}}"
 		}
 	],
 	"tests": [
@@ -28,6 +38,48 @@
 					"standard input[Tree]treeinput",
 					"<input type='hidden' class='PFTree_data' name='standard input[Tree]'>",
 					"data=\"[{&quot;level&quot;:1,&quot;text&quot;:&quot;Test**Test1**Test2&quot;,&quot;node_id&quot;:0,&quot;state&quot;:{&quot;opened&quot;:true}}]"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Tree with height and width params",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Tree with height and width params/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfTreeInputWrapper\">",
+					"pfTreeInput",
+					"standard input[Tree]treeinput",
+					"<input type='hidden' class='PFTree_data' name='standard input[Tree]'>",
+					"height: 300px",
+					"width: 200px",
+					"data=\"[{&quot;level&quot;:1,&quot;text&quot;:&quot;Test**Test1**Test2&quot;,&quot;node_id&quot;:0,&quot;state&quot;:{&quot;opened&quot;:true}}]"
+				],
+				"not-contain": [
+					"params=\"{&quot;multiple&quot;:false,&quot;delimiter&quot;:&quot;:&quot;,&quot;cur_value&quot;:&quot;&quot;}\""
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "Tree with delimiter param",
+			"special-page": {
+				"page": "FormEdit",
+				"query-parameters": "Tree with delimiter param/01",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"pfTreeInputWrapper\">",
+					"pfTreeInput",
+					"standard input[Tree]treeinput",
+					"<input type='hidden' class='PFTree_data' name='standard input[Tree]'>",
+					"data=\"[{&quot;level&quot;:1,&quot;text&quot;:&quot;Test**Test1**Test2&quot;,&quot;node_id&quot;:0,&quot;state&quot;:{&quot;opened&quot;:true}}]",
+					"params=\"{&quot;multiple&quot;:false,&quot;delimiter&quot;:&quot;:&quot;,&quot;cur_value&quot;:&quot;&quot;}\""
 				]
 			}
 		}

--- a/tests/phpunit/integration/includes/PF_FormPrinterTest.php
+++ b/tests/phpunit/integration/includes/PF_FormPrinterTest.php
@@ -9,6 +9,7 @@ if ( !class_exists( 'MediaWikiIntegrationTestCase' ) ) {
 
 /**
  * @covers \PFFormPrinter
+ * @group Database
  *
  * @author Himeshi De Silva
  */
@@ -121,7 +122,7 @@ class PFFormPrinterTest extends MediaWikiIntegrationTestCase {
 			'form_definition' => "====section 4====
 								 {{{section|section 4|level=4|hidden}}}" ],
 		[
-			'expected_form_text' => "<input type=\"hidden\" name=\"_section[section 4]\"/>",
+			'expected_form_text' => "<input type=\"hidden\" name=\"_section[section 4]\"",
 			'expected_page_text' => "====section 4====" ]
 		];
 

--- a/tests/phpunit/integration/includes/PF_FormPrinterTest.php
+++ b/tests/phpunit/integration/includes/PF_FormPrinterTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
 use OOUI\BlankTheme;
 
 if ( !class_exists( 'MediaWikiIntegrationTestCase' ) ) {
@@ -24,7 +25,7 @@ class PFFormPrinterTest extends MediaWikiIntegrationTestCase {
 		// Make sure the form is not in "disabled" state. Unfortunately setting up the global state
 		// environment in a proper way to have PFFormPrinter work on a mock title object is very
 		// difficult. Therefore we just override the permission check by using a hook.
-		Hooks::register( 'PageForms::UserCanEditPage', static function ( $pageTitle, &$userCanEditPage ) {
+		MediaWikiServices::getInstance()->getHookContainer()->register( 'PageForms::UserCanEditPage', static function ( $pageTitle, &$userCanEditPage ) {
 			$userCanEditPage = true;
 			return true;
 		} );

--- a/tests/phpunit/integration/includes/forminputs/PF_RadioButtonInputTest.php
+++ b/tests/phpunit/integration/includes/forminputs/PF_RadioButtonInputTest.php
@@ -4,6 +4,7 @@ use OOUI\BlankTheme;
 
 /**
  * @covers \PFRadioButtonInput
+ * @group Database
  *
  * @author Mark A. Hershberger <mah@nichework.com>
  */
@@ -74,6 +75,10 @@ class PFRadioButtonInputTest extends MediaWikiIntegrationTestCase {
 	 * @param array $expected An associative array containing the expected HTML output for comparison.
 	 */
 	public function testRadioButtons( $setup, $expected ) {
+		if ( version_compare( MW_VERSION, '1.41', '>=' ) ) {
+			$this->markTestSkipped( 'JSONScript tests covers Radiobutton functionality. Consider removing this test completely' );
+		}
+
 		$args = $setup['args'];
 		$args[1] = "TestTemplate123[{$args[1]}]";
 		$result = call_user_func_array(
@@ -437,6 +442,9 @@ class PFRadioButtonInputTest extends MediaWikiIntegrationTestCase {
 	 * @dataProvider radioButtomFromWikitextDataProvider
 	 */
 	public function testRadioButtonsFromWikitext( $setup, $expected ) {
+		if ( version_compare( MW_VERSION, '1.41', '>=' ) ) {
+			$this->markTestSkipped( 'JSONScript tests covers Radiobutton functionality. Consider removing this test completely' );
+		}
 		if ( !isset( $expected['skip'] ) ) {
 			global $wgPageFormsFormPrinter, $wgOut;
 

--- a/tests/phpunit/integration/specials/PFCreateCategoryTest.php
+++ b/tests/phpunit/integration/specials/PFCreateCategoryTest.php
@@ -8,6 +8,7 @@ use MediaWiki\MediaWikiServices;
  * SpecialPageTestBase extends MediaWikiIntegrationTestCase
  *
  * @covers \PFCreateCategory
+ * @group Database
  *
  * @author gesinn-it-ilm
  */

--- a/tests/phpunit/integration/specials/PFCreateFormTest.php
+++ b/tests/phpunit/integration/specials/PFCreateFormTest.php
@@ -4,6 +4,7 @@ use MediaWiki\MediaWikiServices;
 
 /**
  * @covers \PFCreateForm
+ * @group Database
  *
  * @author gesinn-it-wam
  */

--- a/tests/phpunit/integration/specials/PFCreatePropertyTest.php
+++ b/tests/phpunit/integration/specials/PFCreatePropertyTest.php
@@ -4,6 +4,7 @@ use MediaWiki\MediaWikiServices;
 
 /**
  * @covers \PFCreateProperty
+ * @group Database
  *
  * @author gesinn-it-ilm
  */

--- a/tests/phpunit/integration/specials/PFCreateTemplateTest.php
+++ b/tests/phpunit/integration/specials/PFCreateTemplateTest.php
@@ -75,13 +75,17 @@ class PFCreateTemplateTest extends SpecialPageTestBase {
 		</script>
 		EOF;
 
-		$this->assertStringContainsString( '<form id="editform" name="editform" method="post" action="/index.php?title=Template:Thing&amp;action=submit">', $output->mBodytext );
-		$this->assertStringContainsString( '<input type="hidden" value="&lt;noinclude&gt;&#10;{{#template_params:Name (property=Foaf =&gt;name)}}&#10;&lt;/noinclude&gt;&lt;includeonly&gt;{| class=&quot;wikitable&quot;&#10;! Name&#10;| [[Foaf =&gt;name::{{{Name|}}}]]&#10;|-&#10;! &#10;|{{#ask:[[Foaf =&gt;homepage::{{SUBJECTPAGENAME}}]]|format=list}}&#10;|}&#10;&#10;[[Category:Thing]]&#10;&lt;/includeonly&gt;&#10;" name="wpTextbox1">', $output->mBodytext );
-		$this->assertStringContainsString( '<input type="hidden" value="ℳ𝒲♥𝓊𝓃𝒾𝒸ℴ𝒹ℯ" name="wpUnicodeCheck">', $output->mBodytext );
-		$this->assertStringContainsString( '<input type="hidden" name="wpSummary">', $output->mBodytext );
-		$this->assertStringContainsString( '<input type="hidden" value="+\" name="wpEditToken">', $output->mBodytext );
-		$this->assertStringContainsString( '<input type="hidden" name="wpSave">', $output->mBodytext );
-		$this->assertStringContainsString( '<input type="hidden" value="1" name="wpUltimateParam"></form>', $output->mBodytext );
+		if ( version_compare( MW_VERSION, '1.39', '>=' ) ) {
+			$this->assertStringContainsString( '<form id="editform" name="editform" method="post" action="/index.php?title=Template:Thing&amp;action=submit">', $output->mBodytext );
+			$this->assertStringContainsString( '<input type="hidden" value="&lt;noinclude&gt;&#10;{{#template_params:Name (property=Foaf =&gt;name)}}&#10;&lt;/noinclude&gt;&lt;includeonly&gt;{| class=&quot;wikitable&quot;&#10;! Name&#10;| [[Foaf =&gt;name::{{{Name|}}}]]&#10;|-&#10;! &#10;|{{#ask:[[Foaf =&gt;homepage::{{SUBJECTPAGENAME}}]]|format=list}}&#10;|}&#10;&#10;[[Category:Thing]]&#10;&lt;/includeonly&gt;&#10;" name="wpTextbox1">', $output->mBodytext );
+			$this->assertStringContainsString( '<input type="hidden" value="ℳ𝒲♥𝓊𝓃𝒾𝒸ℴ𝒹ℯ" name="wpUnicodeCheck">', $output->mBodytext );
+			$this->assertStringContainsString( '<input type="hidden" name="wpSummary">', $output->mBodytext );
+			$this->assertStringContainsString( '<input type="hidden" value="+\" name="wpEditToken">', $output->mBodytext );
+			$this->assertStringContainsString( '<input type="hidden" name="wpSave">', $output->mBodytext );
+			$this->assertStringContainsString( '<input type="hidden" value="1" name="wpUltimateParam"></form>', $output->mBodytext );
+		} else {
+			$this->assertStringContainsString( '<form id="editform" name="editform" method="post" action="/index.php?title=Template:Thing&amp;action=submit"><input type="hidden" value="&lt;noinclude&gt;&#10;{{#template_params:Name (property=Foaf =&gt;name)}}&#10;&lt;/noinclude&gt;&lt;includeonly&gt;{| class=&quot;wikitable&quot;&#10;! Name&#10;| [[Foaf =&gt;name::{{{Name|}}}]]&#10;|-&#10;! &#10;|{{#ask:[[Foaf =&gt;homepage::{{SUBJECTPAGENAME}}]]|format=list}}&#10;|}&#10;&#10;[[Category:Thing]]&#10;&lt;/includeonly&gt;&#10;" name="wpTextbox1"/><input type="hidden" value="ℳ𝒲♥𝓊𝓃𝒾𝒸ℴ𝒹ℯ" name="wpUnicodeCheck"/><input type="hidden" name="wpSummary"/><input type="hidden" value="+\" name="wpEditToken"/><input type="hidden" name="wpSave"/><input type="hidden" value="1" name="wpUltimateParam"/></form>', $output->mBodytext );
+		}
 
 		// Load the HTML with DOMDocument and DOMXPath
 		$dom = new DomDocument;

--- a/tests/phpunit/integration/specials/PFCreateTemplateTest.php
+++ b/tests/phpunit/integration/specials/PFCreateTemplateTest.php
@@ -75,7 +75,7 @@ class PFCreateTemplateTest extends SpecialPageTestBase {
 		</script>
 		EOF;
 
-		if ( version_compare( MW_VERSION, '1.39', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.41', '>=' ) ) {
 			$this->assertStringContainsString( '<form id="editform" name="editform" method="post" action="/index.php?title=Template:Thing&amp;action=submit">', $output->mBodytext );
 			$this->assertStringContainsString( '<input type="hidden" value="&lt;noinclude&gt;&#10;{{#template_params:Name (property=Foaf =&gt;name)}}&#10;&lt;/noinclude&gt;&lt;includeonly&gt;{| class=&quot;wikitable&quot;&#10;! Name&#10;| [[Foaf =&gt;name::{{{Name|}}}]]&#10;|-&#10;! &#10;|{{#ask:[[Foaf =&gt;homepage::{{SUBJECTPAGENAME}}]]|format=list}}&#10;|}&#10;&#10;[[Category:Thing]]&#10;&lt;/includeonly&gt;&#10;" name="wpTextbox1">', $output->mBodytext );
 			$this->assertStringContainsString( '<input type="hidden" value="ℳ𝒲♥𝓊𝓃𝒾𝒸ℴ𝒹ℯ" name="wpUnicodeCheck">', $output->mBodytext );

--- a/tests/phpunit/integration/specials/PFCreateTemplateTest.php
+++ b/tests/phpunit/integration/specials/PFCreateTemplateTest.php
@@ -4,6 +4,7 @@ use MediaWiki\MediaWikiServices;
 
 /**
  * @covers \PFCreateTemplate
+ * @group Database
  *
  * @author gesinn-it-wam
  */
@@ -74,7 +75,13 @@ class PFCreateTemplateTest extends SpecialPageTestBase {
 		</script>
 		EOF;
 
-		$this->assertStringContainsString( '<form id="editform" name="editform" method="post" action="/index.php?title=Template:Thing&amp;action=submit"><input type="hidden" value="&lt;noinclude&gt;&#10;{{#template_params:Name (property=Foaf =&gt;name)}}&#10;&lt;/noinclude&gt;&lt;includeonly&gt;{| class=&quot;wikitable&quot;&#10;! Name&#10;| [[Foaf =&gt;name::{{{Name|}}}]]&#10;|-&#10;! &#10;|{{#ask:[[Foaf =&gt;homepage::{{SUBJECTPAGENAME}}]]|format=list}}&#10;|}&#10;&#10;[[Category:Thing]]&#10;&lt;/includeonly&gt;&#10;" name="wpTextbox1"/><input type="hidden" value="ℳ𝒲♥𝓊𝓃𝒾𝒸ℴ𝒹ℯ" name="wpUnicodeCheck"/><input type="hidden" name="wpSummary"/><input type="hidden" value="+\" name="wpEditToken"/><input type="hidden" name="wpSave"/><input type="hidden" value="1" name="wpUltimateParam"/></form>', $output->mBodytext );
+		$this->assertStringContainsString( '<form id="editform" name="editform" method="post" action="/index.php?title=Template:Thing&amp;action=submit">', $output->mBodytext );
+		$this->assertStringContainsString( '<input type="hidden" value="&lt;noinclude&gt;&#10;{{#template_params:Name (property=Foaf =&gt;name)}}&#10;&lt;/noinclude&gt;&lt;includeonly&gt;{| class=&quot;wikitable&quot;&#10;! Name&#10;| [[Foaf =&gt;name::{{{Name|}}}]]&#10;|-&#10;! &#10;|{{#ask:[[Foaf =&gt;homepage::{{SUBJECTPAGENAME}}]]|format=list}}&#10;|}&#10;&#10;[[Category:Thing]]&#10;&lt;/includeonly&gt;&#10;" name="wpTextbox1">', $output->mBodytext );
+		$this->assertStringContainsString( '<input type="hidden" value="ℳ𝒲♥𝓊𝓃𝒾𝒸ℴ𝒹ℯ" name="wpUnicodeCheck">', $output->mBodytext );
+		$this->assertStringContainsString( '<input type="hidden" name="wpSummary">', $output->mBodytext );
+		$this->assertStringContainsString( '<input type="hidden" value="+\" name="wpEditToken">', $output->mBodytext );
+		$this->assertStringContainsString( '<input type="hidden" name="wpSave">', $output->mBodytext );
+		$this->assertStringContainsString( '<input type="hidden" value="1" name="wpUltimateParam"></form>', $output->mBodytext );
 
 		// Load the HTML with DOMDocument and DOMXPath
 		$dom = new DomDocument;

--- a/tests/phpunit/integration/specials/PFFormStartTest.php
+++ b/tests/phpunit/integration/specials/PFFormStartTest.php
@@ -4,6 +4,7 @@ use MediaWiki\MediaWikiServices;
 
 /**
  * @covers \PFFormStart
+ * @group Database
  *
  * @author gesinn-it-wam
  */


### PR DESCRIPTION
This PR is related to the issue #87.

This PR contains:

- added `@group Database` where needed
- updated assertions for JSONScript test cases
- used `getWikiPageFactory()` instead of `WikiPage::factory()` for MW 1.39+
- added more test cases to `forminput-radiobutton.json`
- fixed deprecation warning `wfGetDB`
- consider removing `PF_RadioButtonInputTest.php`, for MW `1.41` tests are skipped
- `forminput-radiobutton.json` is there to cover `PF_RadioButtonInput.php` with tests (already some cases added and json test updated)